### PR TITLE
[REFACTOR] 커뮤니티 피드 기본 화면과 HOT 탭 분리

### DIFF
--- a/app/src/main/java/com/issueissyu/fe/di/RepositoryModule.kt
+++ b/app/src/main/java/com/issueissyu/fe/di/RepositoryModule.kt
@@ -54,6 +54,9 @@ abstract class RepositoryModule {
     abstract fun bindLocationRepository(
         impl: LocationRepositoryImpl
     ): LocationRepository
+
+    @Binds
+    @Singleton
     abstract fun bindCommunityRepository(
         impl: CommunityRepositoryImpl
     ): CommunityRepository

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityScreen.kt
@@ -632,10 +632,8 @@ fun PreviewRegionDropdownPill() {
     }
 }
 
-@Preview(showBackground = true)
-@Composable
-fun PreviewCommunityScreen() {
-    val dummyItems = listOf(
+private fun previewCommunityItems(): List<CommunityFeedItem> {
+    return listOf(
         CommunityFeedItem(
             communityId = 1L,
             pinId = null,
@@ -688,11 +686,43 @@ fun PreviewCommunityScreen() {
             isHot = true
         )
     )
-    
+}
+
+@Preview(name = "커뮤니티 홈", showBackground = true)
+@Composable
+fun PreviewCommunityScreenHome() {
     CommunityScreenContent(
         uiState = CommunityUiState(
-            feedItems = dummyItems,
+            feedItems = previewCommunityItems(),
+            selectedTab = CommunityTab.ALL,
+            region = "마포구"
+        ),
+        onBackClick = {},
+        onRegionSelected = {}
+    )
+}
+
+@Preview(name = "커뮤니티 HOT 탭", showBackground = true)
+@Composable
+fun PreviewCommunityScreenHot() {
+    CommunityScreenContent(
+        uiState = CommunityUiState(
+            feedItems = previewCommunityItems(),
             selectedTab = CommunityTab.HOT,
+            region = "마포구"
+        ),
+        onBackClick = {},
+        onRegionSelected = {}
+    )
+}
+
+@Preview(name = "커뮤니티 ISSUE 탭", showBackground = true)
+@Composable
+fun PreviewCommunityScreenIssue() {
+    CommunityScreenContent(
+        uiState = CommunityUiState(
+            feedItems = previewCommunityItems().filter { it.kind == CommunityItemKind.ISSUE },
+            selectedTab = CommunityTab.ISSUE,
             region = "마포구"
         ),
         onBackClick = {},

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityScreen.kt
@@ -64,7 +64,7 @@ fun CommunityScreenContent(
     val colorScheme = MaterialTheme.colorScheme
 
     val categories = remember(colorScheme) {
-        CommunityTab.visibleTabs.map { tab ->
+        CommunityTab.visibleTabs.filter { it != CommunityTab.ALL }.map { tab ->
             when (tab) {
                 CommunityTab.HOT -> CategoryItem(tab.displayName, R.drawable.ic_fire, Issue, colorScheme.errorContainer)
                 CommunityTab.ISSUE -> CategoryItem(tab.displayName, R.drawable.issue, Issue, colorScheme.errorContainer)
@@ -85,7 +85,9 @@ fun CommunityScreenContent(
                 // 1. 카테고리 버튼 (제일 위)
                 CategoryButtons(
                     categories = categories,
-                    selectedCategory = uiState.selectedTab.displayName,
+                    selectedCategory = uiState.selectedTab
+                        .takeIf { it != CommunityTab.ALL }
+                        ?.displayName,
                     onCategorySelected = { name ->
                         onTabSelected(name.toCommunityTab())
                     }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityScreen.kt
@@ -37,7 +37,8 @@ import com.issueissyu.fe.ui.theme.*
 @Composable
 fun CommunityScreen(
     viewModel: CommunityViewModel = hiltViewModel(),
-    onBackClick: (() -> Unit)? = null
+    onBackClick: (() -> Unit)? = null,
+    onCommunityClick: (Long) -> Unit = {}
 ) {
     val uiState by viewModel.uiState.collectAsState()
     
@@ -46,7 +47,8 @@ fun CommunityScreen(
         onBackClick = onBackClick,
         onTabSelected = viewModel::onTabSelected,
         onRefresh = viewModel::onRefresh,
-        onRegionSelected = viewModel::onRegionSelected
+        onRegionSelected = viewModel::onRegionSelected,
+        onCommunityClick = onCommunityClick
     )
 }
 
@@ -57,7 +59,8 @@ fun CommunityScreenContent(
     onBackClick: (() -> Unit)? = null,
     onTabSelected: (CommunityTab) -> Unit = {},
     onRefresh: () -> Unit = {},
-    onRegionSelected: (String) -> Unit = {}
+    onRegionSelected: (String) -> Unit = {},
+    onCommunityClick: (Long) -> Unit = {}
 ) {
     var showRegionSelector by remember { mutableStateOf(false) }
 
@@ -185,27 +188,30 @@ fun CommunityScreenContent(
                     }
                 }
                 else -> {
-                    val isSectionedTab = uiState.selectedTab == CommunityTab.HOT || uiState.selectedTab == CommunityTab.ALL
-                    
+                    val hotItems = uiState.feedItems.filter { it.isHot }
+
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(bottom = 24.dp)
                     ) {
-                        if (isSectionedTab) {
+                        if (uiState.selectedTab == CommunityTab.ALL) {
                             // 대표 카드 영역 (자체적으로 둥근 모서리를 가짐)
                             item {
                                 RepresentativeFeedCard(
                                     item = uiState.feedItems.first(),
-                                    onClick = { /* TODO: 상세 이동 */ },
+                                    onClick = { onCommunityClick(uiState.feedItems.first().communityId) },
                                     modifier = Modifier.padding(16.dp)
                                 )
                             }
 
                             // 우리 동네 인기 소식 섹션 (컨테이너를 둥글게 처리)
-                            val hotItems = uiState.feedItems.filter { it.isHot }
                             if (hotItems.isNotEmpty()) {
                                 item {
-                                    SectionHeader(title = "우리 동네 인기 소식 🔥")
+                                    SectionHeaderWithAction(
+                                        title = "우리 동네 인기 소식 🔥",
+                                        actionText = "더보기",
+                                        onActionClick = { onTabSelected(CommunityTab.HOT) }
+                                    )
                                     Column(
                                         modifier = Modifier
                                             .padding(horizontal = 16.dp)
@@ -215,7 +221,7 @@ fun CommunityScreenContent(
                                         hotItems.take(3).forEachIndexed { index, item ->
                                             CommunityFeedCard(
                                                 item = item,
-                                                onClick = { /* TODO: 상세 이동 */ }
+                                                onClick = { onCommunityClick(item.communityId) }
                                             )
                                             if (index < hotItems.take(3).size - 1) {
                                                 HorizontalDivider(
@@ -241,7 +247,7 @@ fun CommunityScreenContent(
                                     uiState.feedItems.forEachIndexed { index, item ->
                                         CommunityFeedCard(
                                             item = item,
-                                            onClick = { /* TODO: 상세 이동 */ }
+                                            onClick = { onCommunityClick(item.communityId) }
                                         )
                                         if (index < uiState.feedItems.size - 1) {
                                             HorizontalDivider(
@@ -250,6 +256,28 @@ fun CommunityScreenContent(
                                                 thickness = 1.dp
                                             )
                                         }
+                                    }
+                                }
+                            }
+                        } else if (uiState.selectedTab == CommunityTab.HOT) {
+                            val hotListItems = hotItems.ifEmpty { uiState.feedItems }
+
+                            itemsIndexed(hotListItems) { index, item ->
+                                Column(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .background(Color.White)
+                                ) {
+                                    CommunityFeedCard(
+                                        item = item,
+                                        onClick = { onCommunityClick(item.communityId) }
+                                    )
+                                    if (index < hotListItems.size - 1) {
+                                        HorizontalDivider(
+                                            modifier = Modifier.padding(horizontal = 16.dp),
+                                            color = MaterialTheme.colorScheme.surfaceVariant,
+                                            thickness = 1.dp
+                                        )
                                     }
                                 }
                             }
@@ -263,7 +291,7 @@ fun CommunityScreenContent(
                                 ) {
                                     CommunityFeedCard(
                                         item = item,
-                                        onClick = { /* TODO: 상세 이동 */ }
+                                        onClick = { onCommunityClick(item.communityId) }
                                     )
                                     if (index < uiState.feedItems.size - 1) {
                                         HorizontalDivider(
@@ -555,6 +583,42 @@ fun SectionHeader(title: String) {
         ),
         modifier = Modifier.padding(start = 16.dp, end = 16.dp, top = 24.dp, bottom = 12.dp)
     )
+}
+
+@Composable
+fun SectionHeaderWithAction(
+    title: String,
+    actionText: String,
+    onActionClick: () -> Unit
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 16.dp, end = 8.dp, top = 24.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Text(
+            text = title,
+            style = TextStyle(
+                fontFamily = suiteFontFamily,
+                fontWeight = FontWeight.Bold,
+                fontSize = 16.sp,
+                color = MaterialTheme.colorScheme.onBackground
+            ),
+            modifier = Modifier.weight(1f)
+        )
+        TextButton(onClick = onActionClick) {
+            Text(
+                text = actionText,
+                style = TextStyle(
+                    fontFamily = suiteFontFamily,
+                    fontWeight = FontWeight.Bold,
+                    fontSize = 13.sp,
+                    color = BrandColor
+                )
+            )
+        }
+    }
 }
 
 @Preview(showBackground = true)

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityUiState.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/community/CommunityUiState.kt
@@ -4,7 +4,7 @@ import com.issueissyu.fe.domain.model.community.CommunityFeedItem
 import com.issueissyu.fe.domain.model.community.CommunityTab
 
 data class CommunityUiState(
-    val selectedTab: CommunityTab = CommunityTab.HOT, // 피그마 기준 HOT이 첫 번째
+    val selectedTab: CommunityTab = CommunityTab.ALL,
     val region: String = "마포구", // TODO: 실제 사용자 지역 연동 필요
     val feedItems: List<CommunityFeedItem> = emptyList(),
     val isLoading: Boolean = false,


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #40 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
커뮤니티 피드의 기본 홈 화면과 `HOT` 탭 화면을 분리했습니다.

기존에는 커뮤니티 첫 진입 시 `HOT` 탭이 선택된 화면처럼 보일 수 있었으나, 기획 기준에 맞춰 첫 진입 화면은 아무 카테고리도 선택되지 않은 기본 홈 화면으로 정리했습니다.

## 체크리스트
- [ ] Reviewers, Assignees, Labels를 모두 등록했나요?
- [ ] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- 기본 진입 화면에서 카테고리 chip이 선택되지 않은 상태로 보이는지 확인 부탁드립니다.
- `HOT` 탭 클릭 시 핫 게시글 전체 목록으로 분리되는지 확인 부탁드립니다.
- `우리 동네 인기 소식`의 `더보기` 버튼 동작이 적절한지 확인 부탁드립니다.