### PR TITLE
[FEAT] 이슈 신뢰도 조회 API 레이어 추가

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -45,6 +45,7 @@ android {
                 ?: ""
 
         buildConfigField("String", "API_BASE_URL", "\"${localProperties.buildConfigString("API_BASE_URL", "api.base.url", "https://api.example.com/")}\"")
+        buildConfigField("String", "AI_API_BASE_URL", "\"${localProperties.buildConfigString("AI_API_BASE_URL", "ai.api.base.url", "https://fastapi.issueissyu-ai.cloud/")}\"")
         buildConfigField("String", "NAVER_CLIENT_ID", "\"${localProperties.buildConfigString("NAVER_CLIENT_ID", "naver.client.id", "")}\"")
         buildConfigField("String", "NAVER_CLIENT_SECRET", "\"${localProperties.buildConfigString("NAVER_CLIENT_SECRET", "naver.client.secret", "")}\"")
         buildConfigField("String", "NAVER_CLIENT_NAME", "\"${localProperties.buildConfigString("NAVER_CLIENT_NAME", "naver.client.name", "이슈있슈")}\"")

--- a/app/src/main/java/com/issueissyu/fe/core/constants/NetworkConstants.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/constants/NetworkConstants.kt
@@ -4,4 +4,5 @@ import com.issueissyu.fe.BuildConfig
 
 object NetworkConstants {
     val BASE_URL: String = BuildConfig.API_BASE_URL
+    val AI_BASE_URL: String = BuildConfig.AI_API_BASE_URL
 }

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
@@ -1,0 +1,13 @@
+package com.issueissyu.fe.data.remote.api
+
+import com.issueissyu.fe.data.remote.dto.response.BaseResponse
+import com.issueissyu.fe.data.remote.dto.response.issue.IssueReliabilityResponse
+import retrofit2.http.GET
+import retrofit2.http.Path
+
+interface AiIssueApiService {
+    @GET("issues/pin/{pin_id}/reliability")
+    suspend fun getIssueReliability(
+        @Path("pin_id") pinId: Long,
+    ): BaseResponse<IssueReliabilityResponse?>
+}

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/IssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/IssueApiService.kt
@@ -1,17 +1,9 @@
 package com.issueissyu.fe.data.remote.api
 
 import com.issueissyu.fe.data.remote.dto.IssueDto
-import com.issueissyu.fe.data.remote.dto.response.BaseResponse
-import com.issueissyu.fe.data.remote.dto.response.issue.IssueReliabilityResponse
 import retrofit2.http.GET
-import retrofit2.http.Path
 
 interface IssueApiService {
     @GET("issues")
     suspend fun getIssues(): List<IssueDto>
-
-    @GET("issues/pin/{pin_id}/reliability")
-    suspend fun getIssueReliability(
-        @Path("pin_id") pinId: Long,
-    ): BaseResponse<IssueReliabilityResponse?>
 }

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/IssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/IssueApiService.kt
@@ -1,9 +1,17 @@
 package com.issueissyu.fe.data.remote.api
 
 import com.issueissyu.fe.data.remote.dto.IssueDto
+import com.issueissyu.fe.data.remote.dto.response.BaseResponse
+import com.issueissyu.fe.data.remote.dto.response.issue.IssueReliabilityResponse
 import retrofit2.http.GET
+import retrofit2.http.Path
 
 interface IssueApiService {
     @GET("issues")
     suspend fun getIssues(): List<IssueDto>
+
+    @GET("issues/pin/{pin_id}/reliability")
+    suspend fun getIssueReliability(
+        @Path("pin_id") pinId: Long,
+    ): BaseResponse<IssueReliabilityResponse?>
 }

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueReliabilityResponse.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueReliabilityResponse.kt
@@ -25,9 +25,9 @@ fun IssueReliabilityResponse.toDomain(): IssueReliability {
 }
 
 private fun String?.toIssueReliabilityStatus(): IssueReliabilityStatus {
-    return when (this?.lowercase()) {
-        "completed" -> IssueReliabilityStatus.COMPLETED
-        "failed" -> IssueReliabilityStatus.FAILED
+    return when {
+        this.equals("completed", ignoreCase = true) -> IssueReliabilityStatus.COMPLETED
+        this.equals("failed", ignoreCase = true) -> IssueReliabilityStatus.FAILED
         else -> IssueReliabilityStatus.PENDING
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueReliabilityResponse.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueReliabilityResponse.kt
@@ -1,0 +1,33 @@
+package com.issueissyu.fe.data.remote.dto.response.issue
+
+import com.issueissyu.fe.domain.model.issue.IssueReliability
+import com.issueissyu.fe.domain.model.issue.IssueReliabilityStatus
+import kotlin.math.roundToInt
+
+data class IssueReliabilityResponse(
+    val issuePinId: Long,
+    val pinId: Long,
+    val issueConfidence: Double?,
+    val confidenceContent: String?,
+    val reliabilityStatus: String?,
+    val imageUploadStatus: String?,
+)
+
+fun IssueReliabilityResponse.toDomain(): IssueReliability {
+    return IssueReliability(
+        issuePinId = issuePinId,
+        pinId = pinId,
+        score = issueConfidence?.let { (it * 100).roundToInt().coerceIn(0, 100) },
+        reason = confidenceContent,
+        status = reliabilityStatus.toIssueReliabilityStatus(),
+        imageUploadStatus = imageUploadStatus,
+    )
+}
+
+private fun String?.toIssueReliabilityStatus(): IssueReliabilityStatus {
+    return when (this?.lowercase()) {
+        "completed" -> IssueReliabilityStatus.COMPLETED
+        "failed" -> IssueReliabilityStatus.FAILED
+        else -> IssueReliabilityStatus.PENDING
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
@@ -1,6 +1,6 @@
 package com.issueissyu.fe.data.repository
 
-import com.issueissyu.fe.data.remote.api.IssueApiService
+import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.dto.response.issue.toDomain
 import com.issueissyu.fe.domain.model.issue.IssueReliability
 import com.issueissyu.fe.domain.repository.IssueRepository
@@ -9,20 +9,20 @@ import javax.inject.Singleton
 
 @Singleton
 class IssueRepositoryImpl @Inject constructor(
-    private val apiService: IssueApiService,
+    private val aiIssueApiService: AiIssueApiService,
 ) : IssueRepository {
 
     override suspend fun getIssueReliability(pinId: Long): Result<IssueReliability> {
         return try {
-            val response = apiService.getIssueReliability(pinId)
+            val response = aiIssueApiService.getIssueReliability(pinId)
             if (response.isSuccess) {
                 val result = response.result
                     ?: return Result.failure(
-                        Exception(response.message.ifBlank { "이슈 신뢰도 응답이 올바르지 않습니다." }),
+                        Exception(response.message.orEmpty().ifBlank { "이슈 신뢰도 응답이 올바르지 않습니다." }),
                     )
                 Result.success(result.toDomain())
             } else {
-                Result.failure(Exception(response.message.ifBlank { "이슈 신뢰도 조회에 실패했습니다." }))
+                Result.failure(Exception(response.message.orEmpty().ifBlank { "이슈 신뢰도 조회에 실패했습니다." }))
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.issueissyu.fe.data.repository
+
+import com.issueissyu.fe.data.remote.api.IssueApiService
+import com.issueissyu.fe.data.remote.dto.response.issue.toDomain
+import com.issueissyu.fe.domain.model.issue.IssueReliability
+import com.issueissyu.fe.domain.repository.IssueRepository
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class IssueRepositoryImpl @Inject constructor(
+    private val apiService: IssueApiService,
+) : IssueRepository {
+
+    override suspend fun getIssueReliability(pinId: Long): Result<IssueReliability> {
+        return try {
+            val response = apiService.getIssueReliability(pinId)
+            if (response.isSuccess) {
+                val result = response.result
+                    ?: return Result.failure(
+                        Exception(response.message.ifBlank { "이슈 신뢰도 응답이 올바르지 않습니다." }),
+                    )
+                Result.success(result.toDomain())
+            } else {
+                Result.failure(Exception(response.message.ifBlank { "이슈 신뢰도 조회에 실패했습니다." }))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/di/RepositoryModule.kt
+++ b/app/src/main/java/com/issueissyu/fe/di/RepositoryModule.kt
@@ -1,7 +1,7 @@
 package com.issueissyu.fe.di
 
 import com.issueissyu.fe.data.repository.AuthRepositoryImpl
-import com.issueissyu.fe.domain.repository.DefaultIssueRepository
+import com.issueissyu.fe.data.repository.IssueRepositoryImpl
 import com.issueissyu.fe.domain.repository.IssueRepository
 import com.issueissyu.fe.domain.repository.UserRepository
 import com.issueissyu.fe.data.repository.UserRepositoryImpl
@@ -29,7 +29,7 @@ abstract class RepositoryModule {
     @Binds
     @Singleton
     abstract fun bindIssueRepository(
-        defaultIssueRepository: DefaultIssueRepository
+        impl: IssueRepositoryImpl
     ): IssueRepository
 
     @Binds

--- a/app/src/main/java/com/issueissyu/fe/di/network/NetworkModule.kt
+++ b/app/src/main/java/com/issueissyu/fe/di/network/NetworkModule.kt
@@ -18,6 +18,7 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
@@ -76,7 +77,21 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideIssueApiService(retrofit: Retrofit): IssueApiService {
+    @Named("ai")
+    fun provideAiRetrofit(
+        okHttpClient: OkHttpClient,
+        gson: Gson,
+    ): Retrofit {
+        return Retrofit.Builder()
+            .baseUrl(NetworkConstants.AI_BASE_URL)
+            .client(okHttpClient)
+            .addConverterFactory(GsonConverterFactory.create(gson))
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    fun provideIssueApiService(@Named("ai") retrofit: Retrofit): IssueApiService {
         return retrofit.create(IssueApiService::class.java)
     }
 

--- a/app/src/main/java/com/issueissyu/fe/di/network/NetworkModule.kt
+++ b/app/src/main/java/com/issueissyu/fe/di/network/NetworkModule.kt
@@ -6,6 +6,7 @@ import com.issueissyu.fe.BuildConfig
 import com.issueissyu.fe.core.constants.NetworkConstants
 import com.issueissyu.fe.core.network.AuthInterceptor
 import com.issueissyu.fe.core.network.TokenAuthenticator
+import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.api.IssueApiService
 import com.issueissyu.fe.data.remote.api.LocationApi
 import com.issueissyu.fe.data.remote.api.MapApi
@@ -91,8 +92,14 @@ object NetworkModule {
 
     @Provides
     @Singleton
-    fun provideIssueApiService(@Named("ai") retrofit: Retrofit): IssueApiService {
+    fun provideIssueApiService(retrofit: Retrofit): IssueApiService {
         return retrofit.create(IssueApiService::class.java)
+    }
+
+    @Provides
+    @Singleton
+    fun provideAiIssueApiService(@Named("ai") retrofit: Retrofit): AiIssueApiService {
+        return retrofit.create(AiIssueApiService::class.java)
     }
 
     @Provides

--- a/app/src/main/java/com/issueissyu/fe/domain/model/issue/IssueReliability.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/model/issue/IssueReliability.kt
@@ -1,0 +1,16 @@
+package com.issueissyu.fe.domain.model.issue
+
+data class IssueReliability(
+    val issuePinId: Long,
+    val pinId: Long,
+    val score: Int?,
+    val reason: String?,
+    val status: IssueReliabilityStatus,
+    val imageUploadStatus: String?,
+)
+
+enum class IssueReliabilityStatus {
+    PENDING,
+    COMPLETED,
+    FAILED,
+}

--- a/app/src/main/java/com/issueissyu/fe/domain/repository/IssueRepository.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/repository/IssueRepository.kt
@@ -1,17 +1,8 @@
 package com.issueissyu.fe.domain.repository
 
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import com.issueissyu.fe.data.remote.api.IssueApiService
-import javax.inject.Inject
+import com.issueissyu.fe.domain.model.issue.IssueReliability
 
 interface IssueRepository {
     // suspend fun getIssues(): Flow<List<Issue>>
-}
-
-class DefaultIssueRepository @Inject constructor(
-    private val apiService: IssueApiService,
-    private val dataStore: DataStore<Preferences>
-) : IssueRepository {
-    // Implement repository methods here
+    suspend fun getIssueReliability(pinId: Long): Result<IssueReliability>
 }

--- a/app/src/main/java/com/issueissyu/fe/domain/usecase/issue/GetIssueReliabilityUseCase.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/usecase/issue/GetIssueReliabilityUseCase.kt
@@ -1,0 +1,13 @@
+package com.issueissyu.fe.domain.usecase.issue
+
+import com.issueissyu.fe.domain.model.issue.IssueReliability
+import com.issueissyu.fe.domain.repository.IssueRepository
+import javax.inject.Inject
+
+class GetIssueReliabilityUseCase @Inject constructor(
+    private val repository: IssueRepository,
+) {
+    suspend operator fun invoke(pinId: Long): Result<IssueReliability> {
+        return repository.getIssueReliability(pinId)
+    }
+}


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #51 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

### ViewModel 연결 방법

화면에서는 `GetIssueReliabilityUseCase`를 주입받아서 이슈 핀의 `pinId`로 호출하면 됩니다.

```kotlin
@HiltViewModel
class SomeViewModel @Inject constructor(
    private val getIssueReliabilityUseCase: GetIssueReliabilityUseCase,
) : ViewModel() {

    fun loadReliability(pinId: Long) {
        viewModelScope.launch {
            getIssueReliabilityUseCase(pinId)
                .onSuccess { reliability ->
                    // reliability.score: Int?  // 0~100
                    // reliability.reason: String?
                    // reliability.status: IssueReliabilityStatus
                    // PENDING / COMPLETED / FAILED
                }
                .onFailure {
                    // 화면별 에러 처리
                }
        }
    }
}

### UI 컴포넌트 매핑 예시
공통 신뢰도 UI 컴포넌트에는 아래처럼 연결하면 됩니다.

IssueReliabilityIndicator(
    score = reliability.score,
    reason = reliability.reason,
    status = when (reliability.status) {
        IssueReliabilityStatus.PENDING -> IssueReliabilityStatus.PENDING
        IssueReliabilityStatus.COMPLETED -> IssueReliabilityStatus.COMPLETED
        IssueReliabilityStatus.FAILED -> IssueReliabilityStatus.FAILED
    }
)
주의할 점:

이 API는 이슈 핀 전용입니다.
communityId가 아니라 pinId로 호출해야 합니다.
issueConfidence는 서버에서 0.0 ~ 1.0으로 내려오고, domain에서는 0 ~ 100 정수로 변환됩니다.
실패 상태는 점수 0 여부가 아니라 reliabilityStatus == "failed" 기준으로 판단합니다.
pending 상태에서는 score == null일 수 있습니다.