### PR TITLE
[FEAT] 핀 생성 api

### DIFF
--- a/app/src/main/java/com/issueissyu/fe/core/constants/PinImageUploadConstraints.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/constants/PinImageUploadConstraints.kt
@@ -1,0 +1,6 @@
+package com.issueissyu.fe.core.constants
+
+object PinImageUploadConstraints {
+    const val MAX_COUNT = 5
+    const val MAX_TOTAL_BYTES = 45L * 1024L * 1024L
+}

--- a/app/src/main/java/com/issueissyu/fe/core/issue/IssueReliabilityPolling.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/issue/IssueReliabilityPolling.kt
@@ -1,0 +1,30 @@
+package com.issueissyu.fe.core.issue
+
+import com.issueissyu.fe.domain.model.issue.IssueReliability
+import com.issueissyu.fe.domain.model.issue.IssueReliabilityStatus
+import kotlinx.coroutines.delay
+
+object IssueReliabilityPolling {
+    private const val POLL_INTERVAL_MS = 30_000L
+    /** AI 기준 약 5분 내 미완료 시 reliabilityStatus=failed 로 내려온다. */
+    private const val MAX_POLL_DURATION_MS = 5 * 60 * 1_000L + 30_000L
+    private const val MAX_ATTEMPTS = (MAX_POLL_DURATION_MS / POLL_INTERVAL_MS).toInt()
+
+    /**
+     * AI 신뢰도가 [IssueReliabilityStatus.PENDING]일 때 주기적으로 재조회한다.
+     * [IssueReliabilityStatus.COMPLETED] 또는 [IssueReliabilityStatus.FAILED]가 되면 종료한다.
+     */
+    suspend fun fetchWithPolling(
+        fetch: suspend () -> Result<IssueReliability>,
+        onUpdate: suspend (IssueReliability) -> Unit,
+    ) {
+        repeat(MAX_ATTEMPTS) { attempt ->
+            val reliability = fetch().getOrElse { return }
+            onUpdate(reliability)
+            if (reliability.status != IssueReliabilityStatus.PENDING) return
+            if (attempt < MAX_ATTEMPTS - 1) {
+                delay(POLL_INTERVAL_MS)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/core/issue/IssueReliabilityPolling.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/issue/IssueReliabilityPolling.kt
@@ -1,10 +1,13 @@
 package com.issueissyu.fe.core.issue
 
+import android.util.Log
 import com.issueissyu.fe.domain.model.issue.IssueReliability
 import com.issueissyu.fe.domain.model.issue.IssueReliabilityStatus
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 
 object IssueReliabilityPolling {
+    private const val TAG = "IssueReliabilityPolling"
     private const val POLL_INTERVAL_MS = 30_000L
     /** AI 기준 약 5분 내 미완료 시 reliabilityStatus=failed 로 내려온다. */
     private const val MAX_POLL_DURATION_MS = 5 * 60 * 1_000L + 30_000L
@@ -19,7 +22,14 @@ object IssueReliabilityPolling {
         onUpdate: suspend (IssueReliability) -> Unit,
     ) {
         repeat(MAX_ATTEMPTS) { attempt ->
-            val reliability = fetch().getOrElse { return }
+            val reliability = fetch().getOrElse { throwable ->
+                if (throwable is CancellationException) throw throwable
+                Log.w(TAG, "reliability fetch failed attempt=${attempt + 1}/$MAX_ATTEMPTS", throwable)
+                if (attempt < MAX_ATTEMPTS - 1) {
+                    delay(POLL_INTERVAL_MS)
+                }
+                return@repeat
+            }
             onUpdate(reliability)
             if (reliability.status != IssueReliabilityStatus.PENDING) return
             if (attempt < MAX_ATTEMPTS - 1) {

--- a/app/src/main/java/com/issueissyu/fe/core/media/CapturedImageSaver.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/CapturedImageSaver.kt
@@ -1,0 +1,26 @@
+package com.issueissyu.fe.core.media
+
+import android.content.Context
+import android.graphics.Bitmap
+import androidx.core.net.toUri
+import java.io.File
+import java.io.FileOutputStream
+
+object CapturedImageSaver {
+    fun saveJpegToCache(
+        context: Context,
+        bitmap: Bitmap,
+        fileNamePrefix: String,
+    ): String? {
+        return runCatching {
+            val file = File(
+                context.cacheDir,
+                "$fileNamePrefix-${System.currentTimeMillis()}.jpg",
+            )
+            FileOutputStream(file).use { output ->
+                bitmap.compress(Bitmap.CompressFormat.JPEG, 92, output)
+            }
+            file.toUri().toString()
+        }.getOrNull()
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageMimeResolver.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageMimeResolver.kt
@@ -1,0 +1,139 @@
+package com.issueissyu.fe.core.media
+
+import android.content.Context
+import android.net.Uri
+import android.webkit.MimeTypeMap
+
+enum class PinImageMimeSource {
+    CONTENT_RESOLVER,
+    EXTENSION,
+    BYTE_SIGNATURE,
+    FALLBACK_JPEG,
+}
+
+data class PinImageMimeResolution(
+    val mimeType: String,
+    val source: PinImageMimeSource,
+    /** ContentResolver.getType(uri) 원본. null·빈값·image/*면 2·3단계로 넘어간 경우. */
+    val contentResolverMime: String?,
+)
+
+object PinImageMimeResolver {
+
+    fun resolve(
+        context: Context,
+        uri: Uri,
+        fileName: String,
+        bytes: ByteArray,
+    ): PinImageMimeResolution {
+        val resolverMime = context.contentResolver.getType(uri)
+        if (!resolverMime.isNullOrBlank() && resolverMime != "image/*") {
+            return PinImageMimeResolution(
+                mimeType = resolverMime,
+                source = PinImageMimeSource.CONTENT_RESOLVER,
+                contentResolverMime = resolverMime,
+            )
+        }
+
+        val extension = fileName.substringAfterLast('.', "").lowercase()
+        if (extension.isNotBlank()) {
+            val extensionMime = when (extension) {
+                "jpg", "jpeg" -> "image/jpeg"
+                "png" -> "image/png"
+                "gif" -> "image/gif"
+                "webp" -> "image/webp"
+                "heic" -> "image/heic"
+                "heif" -> "image/heif"
+                else -> MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+            }
+            if (!extensionMime.isNullOrBlank()) {
+                return PinImageMimeResolution(
+                    mimeType = extensionMime,
+                    source = PinImageMimeSource.EXTENSION,
+                    contentResolverMime = resolverMime,
+                )
+            }
+        }
+
+        val signatureMime = sniffImageMimeType(bytes)
+        if (signatureMime != null) {
+            return PinImageMimeResolution(
+                mimeType = signatureMime,
+                source = PinImageMimeSource.BYTE_SIGNATURE,
+                contentResolverMime = resolverMime,
+            )
+        }
+
+        return PinImageMimeResolution(
+            mimeType = "image/jpeg",
+            source = PinImageMimeSource.FALLBACK_JPEG,
+            contentResolverMime = resolverMime,
+        )
+    }
+
+    fun ensureExtension(fileName: String, mimeType: String): String {
+        if (fileName.contains('.')) return fileName
+        val extension = when (mimeType.lowercase()) {
+            "image/png" -> "png"
+            "image/webp" -> "webp"
+            "image/gif" -> "gif"
+            "image/heic" -> "heic"
+            "image/heif" -> "heif"
+            else -> "jpg"
+        }
+        return "$fileName.$extension"
+    }
+
+    private fun sniffImageMimeType(bytes: ByteArray): String? {
+        if (bytes.size >= 3 &&
+            bytes[0] == 0xFF.toByte() &&
+            bytes[1] == 0xD8.toByte() &&
+            bytes[2] == 0xFF.toByte()
+        ) {
+            return "image/jpeg"
+        }
+
+        if (bytes.size >= 8 &&
+            bytes[0] == 0x89.toByte() &&
+            bytes[1] == 0x50.toByte() &&
+            bytes[2] == 0x4E.toByte() &&
+            bytes[3] == 0x47.toByte() &&
+            bytes[4] == 0x0D.toByte() &&
+            bytes[5] == 0x0A.toByte() &&
+            bytes[6] == 0x1A.toByte() &&
+            bytes[7] == 0x0A.toByte()
+        ) {
+            return "image/png"
+        }
+
+        if (bytes.size >= 6) {
+            val header = bytes.copyOfRange(0, 6).decodeToString()
+            if (header == "GIF87a" || header == "GIF89a") {
+                return "image/gif"
+            }
+        }
+
+        if (bytes.size >= 12) {
+            val riff = bytes.copyOfRange(0, 4).decodeToString()
+            val webp = bytes.copyOfRange(8, 12).decodeToString()
+            if (riff == "RIFF" && webp == "WEBP") {
+                return "image/webp"
+            }
+        }
+
+        if (bytes.size >= 12) {
+            val boxType = bytes.copyOfRange(4, 8).decodeToString()
+            if (boxType == "ftyp") {
+                val majorBrand = bytes.copyOfRange(8, 12).decodeToString().lowercase()
+                if (majorBrand.startsWith("hei") || majorBrand.startsWith("hev")) {
+                    return "image/heic"
+                }
+                if (majorBrand.startsWith("mif")) {
+                    return "image/heif"
+                }
+            }
+        }
+
+        return null
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageMimeResolver.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageMimeResolver.kt
@@ -14,7 +14,7 @@ enum class PinImageMimeSource {
 data class PinImageMimeResolution(
     val mimeType: String,
     val source: PinImageMimeSource,
-    /** ContentResolver.getType(uri) 원본. null·빈값·image/*면 2·3단계로 넘어간 경우. */
+    // ContentResolver.getType(uri) 원본. null·빈값·image/*면 2·3단계로 넘어간 경우.
     val contentResolverMime: String?,
 )
 

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadDiagnostics.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadDiagnostics.kt
@@ -39,7 +39,14 @@ object PinImageUploadDiagnostics {
         httpStatus: Int?,
         serverCode: String?,
         metas: List<PinImageUploadMeta>,
+        responseBody: String? = null,
     ) {
+        if (!responseBody.isNullOrBlank()) {
+            Log.w(
+                TAG,
+                "upload_failed_response status=$httpStatus code=${serverCode ?: "null"} body=$responseBody",
+            )
+        }
         metas.forEachIndexed { index, meta ->
             Log.w(
                 TAG,

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadDiagnostics.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadDiagnostics.kt
@@ -1,0 +1,56 @@
+package com.issueissyu.fe.core.media
+
+import android.util.Log
+
+data class PinImageUploadMeta(
+    val uriScheme: String,
+    val fileName: String,
+    val resolvedMime: String,
+    val mimeSource: PinImageMimeSource,
+    /** getType(uri) 원본 (null이면 시스템이 MIME을 주지 않은 경우) */
+    val contentResolverMime: String?,
+    /** 파일 앞 16바이트 hex — 시그니처 판별·fallback 원인 분석용 */
+    val header: String,
+)
+
+object PinImageUploadDiagnostics {
+    private const val TAG = "PIN_IMAGE_UPLOAD"
+
+    fun formatHeaderHex(bytes: ByteArray, length: Int = 16): String =
+        bytes.take(length).joinToString("") { "%02X".format(it) }
+
+    fun logMimeFallback(
+        resolution: PinImageMimeResolution,
+        fileName: String,
+        uriScheme: String,
+        bytes: ByteArray? = null,
+    ) {
+        if (resolution.source != PinImageMimeSource.FALLBACK_JPEG) return
+        val header = bytes?.let { formatHeaderHex(it) } ?: "unknown"
+        val resolverMime = resolution.contentResolverMime?.ifBlank { null } ?: "null"
+        Log.w(
+            TAG,
+            "mime_inference_fallback resolverMime=$resolverMime fileName=$fileName " +
+                "uriScheme=$uriScheme resolvedMime=${resolution.mimeType} header=$header",
+        )
+    }
+
+    fun logUploadFailure(
+        httpStatus: Int?,
+        serverCode: String?,
+        metas: List<PinImageUploadMeta>,
+    ) {
+        metas.forEachIndexed { index, meta ->
+            Log.w(
+                TAG,
+                "upload_failed status=$httpStatus code=$serverCode index=$index " +
+                    "mime=${meta.resolvedMime} resolverMime=${meta.contentResolverMime ?: "null"} " +
+                    "file=${meta.fileName} scheme=${meta.uriScheme} mimeSource=${meta.mimeSource} " +
+                    "header=${meta.header}",
+            )
+        }
+        if (metas.isEmpty()) {
+            Log.w(TAG, "upload_failed status=$httpStatus code=$serverCode imageCount=0")
+        }
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadDiagnostics.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadDiagnostics.kt
@@ -5,6 +5,8 @@ import android.util.Log
 data class PinImageUploadMeta(
     val uriScheme: String,
     val fileName: String,
+    val uploadFilename: String,
+    val byteSize: Int,
     val resolvedMime: String,
     val mimeSource: PinImageMimeSource,
     /** getType(uri) 원본 (null이면 시스템이 MIME을 주지 않은 경우) */
@@ -18,6 +20,20 @@ object PinImageUploadDiagnostics {
 
     fun formatHeaderHex(bytes: ByteArray, length: Int = 16): String =
         bytes.take(length).joinToString("") { "%02X".format(it) }
+
+    fun logUploadPrepare(category: String, metas: List<PinImageUploadMeta>) {
+        Log.i(TAG, "upload_prepare category=$category imageCount=${metas.size}")
+        metas.forEachIndexed { index, meta ->
+            Log.i(
+                TAG,
+                "upload_prepare index=$index category=$category bytes=${meta.byteSize} " +
+                    "mime=${meta.resolvedMime} mimeSource=${meta.mimeSource} " +
+                    "resolverMime=${meta.contentResolverMime ?: "null"} " +
+                    "fileName=${meta.fileName} uploadFilename=${meta.uploadFilename} " +
+                    "scheme=${meta.uriScheme} header=${meta.header}",
+            )
+        }
+    }
 
     fun logMimeFallback(
         resolution: PinImageMimeResolution,
@@ -51,8 +67,10 @@ object PinImageUploadDiagnostics {
             Log.w(
                 TAG,
                 "upload_failed status=$httpStatus code=$serverCode index=$index " +
-                    "mime=${meta.resolvedMime} resolverMime=${meta.contentResolverMime ?: "null"} " +
-                    "file=${meta.fileName} scheme=${meta.uriScheme} mimeSource=${meta.mimeSource} " +
+                    "bytes=${meta.byteSize} mime=${meta.resolvedMime} " +
+                    "resolverMime=${meta.contentResolverMime ?: "null"} " +
+                    "file=${meta.fileName} uploadFilename=${meta.uploadFilename} " +
+                    "scheme=${meta.uriScheme} mimeSource=${meta.mimeSource} " +
                     "header=${meta.header}",
             )
         }

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadValidator.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadValidator.kt
@@ -2,6 +2,7 @@ package com.issueissyu.fe.core.media
 
 import android.content.Context
 import android.net.Uri
+import android.provider.OpenableColumns
 import com.issueissyu.fe.core.constants.PinImageUploadConstraints
 
 object PinImageUploadValidator {
@@ -18,14 +19,41 @@ object PinImageUploadValidator {
         var totalBytes = 0L
         imageUris.forEach { uriString ->
             val uri = Uri.parse(uriString)
-            val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+            val bytes = resolveUriSizeBytes(context, uri)
                 ?: return Result.failure(IllegalArgumentException("첨부한 사진을 읽을 수 없습니다."))
-            totalBytes += bytes.size
+            if (bytes <= 0L) {
+                return Result.failure(IllegalArgumentException("첨부한 사진을 확인할 수 없습니다."))
+            }
+            totalBytes += bytes
             if (totalBytes > PinImageUploadConstraints.MAX_TOTAL_BYTES) {
                 return Result.failure(IllegalArgumentException("사진 전체 용량은 45MB를 넘을 수 없습니다."))
             }
         }
 
         return Result.success(Unit)
+    }
+
+    private fun resolveUriSizeBytes(context: Context, uri: Uri): Long? {
+        context.contentResolver.query(
+            uri,
+            arrayOf(OpenableColumns.SIZE),
+            null,
+            null,
+            null,
+        )?.use { cursor ->
+            if (cursor.moveToFirst()) {
+                val index = cursor.getColumnIndex(OpenableColumns.SIZE)
+                if (index >= 0 && !cursor.isNull(index)) {
+                    val size = cursor.getLong(index)
+                    if (size > 0L) return size
+                }
+            }
+        }
+
+        return runCatching {
+            context.contentResolver.openAssetFileDescriptor(uri, "r")?.use { descriptor ->
+                descriptor.length.takeIf { length -> length > 0L }
+            }
+        }.getOrNull()
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadValidator.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/PinImageUploadValidator.kt
@@ -1,0 +1,31 @@
+package com.issueissyu.fe.core.media
+
+import android.content.Context
+import android.net.Uri
+import com.issueissyu.fe.core.constants.PinImageUploadConstraints
+
+object PinImageUploadValidator {
+
+    fun validate(context: Context, imageUris: List<String>): Result<Unit> {
+        if (imageUris.size > PinImageUploadConstraints.MAX_COUNT) {
+            return Result.failure(
+                IllegalArgumentException(
+                    "사진은 최대 ${PinImageUploadConstraints.MAX_COUNT}장까지 첨부할 수 있습니다.",
+                ),
+            )
+        }
+
+        var totalBytes = 0L
+        imageUris.forEach { uriString ->
+            val uri = Uri.parse(uriString)
+            val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                ?: return Result.failure(IllegalArgumentException("첨부한 사진을 읽을 수 없습니다."))
+            totalBytes += bytes.size
+            if (totalBytes > PinImageUploadConstraints.MAX_TOTAL_BYTES) {
+                return Result.failure(IllegalArgumentException("사진 전체 용량은 45MB를 넘을 수 없습니다."))
+            }
+        }
+
+        return Result.success(Unit)
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/core/media/RememberPhotoSourcePicker.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/RememberPhotoSourcePicker.kt
@@ -1,0 +1,143 @@
+package com.issueissyu.fe.core.media
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.widget.Toast
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.runtime.Stable
+import androidx.compose.ui.platform.LocalContext
+import androidx.core.content.ContextCompat
+import com.issueissyu.fe.ui.components.PhotoAddSourceBottomSheet
+
+@Stable
+class PhotoSourcePickerState internal constructor(
+    val showSourceSheet: () -> Unit,
+    internal val photoSourceBottomSheet: @Composable () -> Unit,
+) {
+    @Composable
+    fun PhotoSourceBottomSheet() {
+        photoSourceBottomSheet()
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun rememberPhotoSourcePicker(
+    currentCount: Int,
+    maxCount: Int,
+    onImagesPicked: (List<String>) -> Unit,
+    cameraFileNamePrefix: String,
+): PhotoSourcePickerState {
+    val context = LocalContext.current
+    var showPhotoSourceSheet by remember { mutableStateOf(false) }
+
+    val remainingSlots = (maxCount - currentCount).coerceAtLeast(0)
+    val albumPickRequest = remember {
+        PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+    }
+
+    var launchAlbumPicker by remember { mutableStateOf<(() -> Unit)?>(null) }
+
+    if (remainingSlots > 1) {
+        key(remainingSlots) {
+            val imagePickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = remainingSlots),
+            ) { uris ->
+                onImagesPicked(uris.map { it.toString() })
+            }
+            SideEffect {
+                launchAlbumPicker = {
+                    imagePickerLauncher.launch(albumPickRequest)
+                }
+            }
+        }
+    } else if (remainingSlots == 1) {
+        key("single-album") {
+            val imagePickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.PickVisualMedia(),
+            ) { uri ->
+                uri?.let { picked -> onImagesPicked(listOf(picked.toString())) }
+            }
+            SideEffect {
+                launchAlbumPicker = {
+                    imagePickerLauncher.launch(albumPickRequest)
+                }
+            }
+        }
+    } else {
+        SideEffect {
+            launchAlbumPicker = null
+        }
+    }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicturePreview(),
+    ) { bitmap ->
+        when {
+            bitmap == null -> Unit
+            else -> {
+                val uri = CapturedImageSaver.saveJpegToCache(context, bitmap, cameraFileNamePrefix)
+                if (uri == null) {
+                    Toast.makeText(context, "사진을 저장하지 못했습니다.", Toast.LENGTH_SHORT).show()
+                } else {
+                    onImagesPicked(listOf(uri))
+                }
+            }
+        }
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            cameraLauncher.launch(null)
+        } else {
+            Toast.makeText(context, "카메라 권한이 필요합니다.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val launchCamera = remember(cameraLauncher, cameraPermissionLauncher, context) {
+        {
+            showPhotoSourceSheet = false
+            val hasPermission = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (hasPermission) {
+                cameraLauncher.launch(null)
+            } else {
+                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            }
+        }
+    }
+
+    val launchAlbum: () -> Unit = remember {
+        {
+            showPhotoSourceSheet = false
+            launchAlbumPicker?.invoke()
+        }
+    }
+
+    return PhotoSourcePickerState(
+        showSourceSheet = { showPhotoSourceSheet = true },
+        photoSourceBottomSheet = {
+            if (showPhotoSourceSheet) {
+                PhotoAddSourceBottomSheet(
+                    onDismissRequest = { showPhotoSourceSheet = false },
+                    onAlbumClick = launchAlbum,
+                    onCameraClick = launchCamera,
+                )
+            }
+        },
+    )
+}

--- a/app/src/main/java/com/issueissyu/fe/core/media/RememberPhotoSourcePicker.kt
+++ b/app/src/main/java/com/issueissyu/fe/core/media/RememberPhotoSourcePicker.kt
@@ -8,9 +8,7 @@ import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
@@ -46,38 +44,18 @@ fun rememberPhotoSourcePicker(
         PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
     }
 
-    var launchAlbumPicker by remember { mutableStateOf<(() -> Unit)?>(null) }
+    val singleImagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.GetContent(),
+    ) { uri ->
+        uri?.let { picked -> onImagesPicked(listOf(picked.toString())) }
+    }
 
-    if (remainingSlots > 1) {
-        key(remainingSlots) {
-            val imagePickerLauncher = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = remainingSlots),
-            ) { uris ->
-                onImagesPicked(uris.map { it.toString() })
-            }
-            SideEffect {
-                launchAlbumPicker = {
-                    imagePickerLauncher.launch(albumPickRequest)
-                }
-            }
-        }
-    } else if (remainingSlots == 1) {
-        key("single-album") {
-            val imagePickerLauncher = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.PickVisualMedia(),
-            ) { uri ->
-                uri?.let { picked -> onImagesPicked(listOf(picked.toString())) }
-            }
-            SideEffect {
-                launchAlbumPicker = {
-                    imagePickerLauncher.launch(albumPickRequest)
-                }
-            }
-        }
-    } else {
-        SideEffect {
-            launchAlbumPicker = null
-        }
+    val multipleImagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(
+            maxItems = remainingSlots.coerceAtLeast(2),
+        ),
+    ) { uris ->
+        onImagesPicked(uris.map { it.toString() })
     }
 
     val cameraLauncher = rememberLauncherForActivityResult(
@@ -121,10 +99,18 @@ fun rememberPhotoSourcePicker(
         }
     }
 
-    val launchAlbum: () -> Unit = remember {
+    val launchAlbum: () -> Unit = remember(
+        remainingSlots,
+        singleImagePickerLauncher,
+        multipleImagePickerLauncher,
+        albumPickRequest,
+    ) {
         {
             showPhotoSourceSheet = false
-            launchAlbumPicker?.invoke()
+            when {
+                remainingSlots > 1 -> multipleImagePickerLauncher.launch(albumPickRequest)
+                remainingSlots == 1 -> singleImagePickerLauncher.launch("image/*")
+            }
         }
     }
 

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
@@ -1,11 +1,25 @@
 package com.issueissyu.fe.data.remote.api
 
 import com.issueissyu.fe.data.remote.dto.response.BaseResponse
+import com.issueissyu.fe.data.remote.dto.response.issue.IssueAiDraftResponse
 import com.issueissyu.fe.data.remote.dto.response.issue.IssueReliabilityResponse
+import retrofit2.http.Field
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.POST
 import retrofit2.http.Path
 
 interface AiIssueApiService {
+    @FormUrlEncoded
+    @POST("issues/pin/ai")
+    suspend fun createIssuePinAiDraft(
+        @Field("title") title: String,
+        @Field("content") content: String,
+        @Field("tone") tone: String,
+        @Field("latitude") latitude: Double,
+        @Field("longitude") longitude: Double,
+    ): BaseResponse<IssueAiDraftResponse?>
+
     @GET("issues/pin/{pin_id}/reliability")
     suspend fun getIssueReliability(
         @Path("pin_id") pinId: Long,

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
@@ -3,6 +3,7 @@ package com.issueissyu.fe.data.remote.api
 import com.issueissyu.fe.data.remote.dto.response.BaseResponse
 import com.issueissyu.fe.data.remote.dto.response.issue.IssueAiDraftResponse
 import com.issueissyu.fe.data.remote.dto.response.issue.IssueReliabilityResponse
+import com.issueissyu.fe.data.remote.dto.response.issue.IssueToneTypeResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.PinImportResponse
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
@@ -15,6 +16,9 @@ import okhttp3.MultipartBody
 import okhttp3.RequestBody
 
 interface AiIssueApiService {
+    @GET("issues/tone-types")
+    suspend fun getIssueToneTypes(): BaseResponse<List<IssueToneTypeResponse>?>
+
     @FormUrlEncoded
     @POST("issues/pin/ai")
     suspend fun createIssuePinAiDraft(

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
@@ -28,12 +28,8 @@ interface AiIssueApiService {
     @Multipart
     @POST("issues/pin")
     suspend fun createIssuePin(
-        @Part("title") title: RequestBody,
-        @Part("content") content: RequestBody,
-        @Part("tone") tone: RequestBody,
-        @Part("latitude") latitude: RequestBody,
-        @Part("longitude") longitude: RequestBody,
-        @Part images: List<MultipartBody.Part>,
+        @Part("request") request: RequestBody,
+        @Part photos: List<MultipartBody.Part>,
     ): BaseResponse<PinImportResponse?>
 
     @GET("issues/pin/{pin_id}/reliability")

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/AiIssueApiService.kt
@@ -3,11 +3,16 @@ package com.issueissyu.fe.data.remote.api
 import com.issueissyu.fe.data.remote.dto.response.BaseResponse
 import com.issueissyu.fe.data.remote.dto.response.issue.IssueAiDraftResponse
 import com.issueissyu.fe.data.remote.dto.response.issue.IssueReliabilityResponse
+import com.issueissyu.fe.data.remote.dto.response.pin.PinImportResponse
 import retrofit2.http.Field
 import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
+import retrofit2.http.Multipart
 import retrofit2.http.POST
+import retrofit2.http.Part
 import retrofit2.http.Path
+import okhttp3.MultipartBody
+import okhttp3.RequestBody
 
 interface AiIssueApiService {
     @FormUrlEncoded
@@ -19,6 +24,17 @@ interface AiIssueApiService {
         @Field("latitude") latitude: Double,
         @Field("longitude") longitude: Double,
     ): BaseResponse<IssueAiDraftResponse?>
+
+    @Multipart
+    @POST("issues/pin")
+    suspend fun createIssuePin(
+        @Part("title") title: RequestBody,
+        @Part("content") content: RequestBody,
+        @Part("tone") tone: RequestBody,
+        @Part("latitude") latitude: RequestBody,
+        @Part("longitude") longitude: RequestBody,
+        @Part images: List<MultipartBody.Part>,
+    ): BaseResponse<PinImportResponse?>
 
     @GET("issues/pin/{pin_id}/reliability")
     suspend fun getIssueReliability(

--- a/app/src/main/java/com/issueissyu/fe/data/remote/api/PinApi.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/api/PinApi.kt
@@ -21,7 +21,9 @@ import com.issueissyu.fe.data.remote.dto.response.pin.ProblemSolverJoinResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.ProblemSolverListResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.ProblemSolverPhotoResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.ProblemSolverVerificationResponse
+import com.issueissyu.fe.data.remote.dto.response.pin.PinImportResponse
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -182,4 +184,12 @@ interface PinApi {
     suspend fun joinIssuePetition(
         @Path("pinId") pinId: Long
     ): BaseResponse<PetitionsJoinResponse?>
+
+    // 소통 핀 통합 등록
+    @Multipart
+    @POST("api/pins/import/communication")
+    suspend fun createCommunicationPin(
+        @Part("request") request: RequestBody,
+        @Part photos: List<MultipartBody.Part>,
+    ): BaseResponse<PinImportResponse?>
 }

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/request/pin/PinImportRequests.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/request/pin/PinImportRequests.kt
@@ -3,12 +3,11 @@ package com.issueissyu.fe.data.remote.dto.request.pin
 data class CommunicationPinImportRequest(
     val lat: Double,
     val lng: Double,
-    val pinImageUrls: List<PinImageItemRequest>,
+    val pinImages: List<PinImageItemRequest>? = null,
     val pinTitle: String,
     val pinContent: String,
 )
 
 data class PinImageItemRequest(
-    val pinImageUrl: String,
     val isMain: Boolean,
 )

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/request/pin/PinImportRequests.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/request/pin/PinImportRequests.kt
@@ -1,0 +1,14 @@
+package com.issueissyu.fe.data.remote.dto.request.pin
+
+data class CommunicationPinImportRequest(
+    val lat: Double,
+    val lng: Double,
+    val pinImageUrls: List<PinImageItemRequest>,
+    val pinTitle: String,
+    val pinContent: String,
+)
+
+data class PinImageItemRequest(
+    val pinImageUrl: String,
+    val isMain: Boolean,
+)

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/request/pin/PinImportRequests.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/request/pin/PinImportRequests.kt
@@ -8,6 +8,14 @@ data class CommunicationPinImportRequest(
     val pinContent: String,
 )
 
+data class IssuePinImportRequest(
+    val lat: Double,
+    val lng: Double,
+    val pinTitle: String,
+    val pinContent: String,
+    val pinImages: List<PinImageItemRequest>? = null,
+)
+
 data class PinImageItemRequest(
     val isMain: Boolean,
 )

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueAiDraftResponse.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueAiDraftResponse.kt
@@ -1,0 +1,24 @@
+package com.issueissyu.fe.data.remote.dto.response.issue
+
+import com.issueissyu.fe.domain.model.issue.IssueAiDraft
+
+data class IssueAiDraftResponse(
+    val title: String? = null,
+    val pinTitle: String? = null,
+    val content: String? = null,
+    val pinContent: String? = null,
+    val description: String? = null,
+    val generatedContent: String? = null,
+)
+
+fun IssueAiDraftResponse.toDomain(): IssueAiDraft {
+    return IssueAiDraft(
+        title = title.firstNotBlank(pinTitle),
+        content = content.firstNotBlank(pinContent, description, generatedContent),
+    )
+}
+
+private fun String?.firstNotBlank(vararg candidates: String?): String? {
+    return sequenceOf(this, *candidates)
+        .firstOrNull { !it.isNullOrBlank() }
+}

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueToneTypeResponse.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/issue/IssueToneTypeResponse.kt
@@ -1,0 +1,16 @@
+package com.issueissyu.fe.data.remote.dto.response.issue
+
+import com.issueissyu.fe.domain.model.issue.IssueToneType
+
+data class IssueToneTypeResponse(
+    val key: String = "",
+    val label: String = "",
+)
+
+fun IssueToneTypeResponse.toDomain(): IssueToneType? {
+    val normalizedLabel = label.takeIf { it.isNotBlank() } ?: return null
+    return IssueToneType(
+        key = key.takeIf { it.isNotBlank() },
+        label = normalizedLabel,
+    )
+}

--- a/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/pin/PinImportResponses.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/remote/dto/response/pin/PinImportResponses.kt
@@ -1,0 +1,18 @@
+package com.issueissyu.fe.data.remote.dto.response.pin
+
+data class PinImportResponse(
+    val pinId: Long = 0,
+    val pinType: String? = null,
+    val region: String? = null,
+    val pinDetailAddress: String? = null,
+    val pinImageUrls: List<PinImageWithIdResponse>? = null,
+    val toneType: String? = null,
+    val createdAt: String? = null,
+    val updatedAt: String? = null,
+)
+
+data class PinImageWithIdResponse(
+    val pinImageId: Long = 0,
+    val pinImageUrl: String = "",
+    val isMain: Boolean = false,
+)

--- a/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.issueissyu.fe.data.repository
 
 import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.dto.response.issue.toDomain
+import com.issueissyu.fe.domain.model.issue.IssueAiDraft
 import com.issueissyu.fe.domain.model.issue.IssueReliability
 import com.issueissyu.fe.domain.repository.IssueRepository
 import javax.inject.Inject
@@ -11,6 +12,40 @@ import javax.inject.Singleton
 class IssueRepositoryImpl @Inject constructor(
     private val aiIssueApiService: AiIssueApiService,
 ) : IssueRepository {
+
+    override suspend fun createIssueAiDraft(
+        title: String,
+        content: String,
+        tone: String,
+        latitude: Double,
+        longitude: Double,
+    ): Result<IssueAiDraft> {
+        return try {
+            val response = aiIssueApiService.createIssuePinAiDraft(
+                title = title,
+                content = content,
+                tone = tone,
+                latitude = latitude,
+                longitude = longitude,
+            )
+            if (response.isSuccess) {
+                val result = response.result
+                    ?: return Result.failure(
+                        Exception(response.message.orEmpty().ifBlank { "AI 글쓰기 응답이 올바르지 않습니다." }),
+                    )
+                val draft = result.toDomain()
+                if (draft.content.isNullOrBlank()) {
+                    Result.failure(Exception(response.message.orEmpty().ifBlank { "AI 글쓰기 결과 본문이 비어 있습니다." }))
+                } else {
+                    Result.success(draft)
+                }
+            } else {
+                Result.failure(Exception(response.message.orEmpty().ifBlank { "AI 글쓰기에 실패했습니다." }))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 
     override suspend fun getIssueReliability(pinId: Long): Result<IssueReliability> {
         return try {

--- a/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/IssueRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.dto.response.issue.toDomain
 import com.issueissyu.fe.domain.model.issue.IssueAiDraft
 import com.issueissyu.fe.domain.model.issue.IssueReliability
+import com.issueissyu.fe.domain.model.issue.IssueToneType
 import com.issueissyu.fe.domain.repository.IssueRepository
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -12,6 +13,27 @@ import javax.inject.Singleton
 class IssueRepositoryImpl @Inject constructor(
     private val aiIssueApiService: AiIssueApiService,
 ) : IssueRepository {
+
+    override suspend fun getIssueToneTypes(): Result<List<IssueToneType>> {
+        return try {
+            val response = aiIssueApiService.getIssueToneTypes()
+            if (response.isSuccess) {
+                val tones = response.result.orEmpty()
+                    .mapNotNull { it.toDomain() }
+                if (tones.isEmpty()) {
+                    Result.failure(Exception("말투 목록이 비어 있습니다."))
+                } else {
+                    Result.success(tones)
+                }
+            } else {
+                Result.failure(
+                    Exception(response.message.orEmpty().ifBlank { "말투 목록을 불러오지 못했습니다." }),
+                )
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 
     override suspend fun createIssueAiDraft(
         title: String,

--- a/app/src/main/java/com/issueissyu/fe/data/repository/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/LocationRepositoryImpl.kt
@@ -20,6 +20,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
+import retrofit2.HttpException
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -168,6 +169,12 @@ class LocationRepositoryImpl @Inject constructor(
                 Result.success(response.result?.address?.takeIf { it.isNotBlank() }.orEmpty())
             } else {
                 Result.failure(Exception(response.message.ifBlank { "이 위치에는 핀을 생성할 수 없습니다." }))
+            }
+        } catch (e: HttpException) {
+            if (e.code() == 403) {
+                Result.failure(Exception("이 위치에는 핀을 생성할 수 없습니다. 다른 위치를 선택해주세요."))
+            } else {
+                Result.failure(e)
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/app/src/main/java/com/issueissyu/fe/data/repository/LocationRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/LocationRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.issueissyu.fe.data.repository
 import android.content.Context
 import android.location.Geocoder
 import android.os.Build
+import com.google.gson.Gson
 import com.issueissyu.fe.data.remote.api.LocationApi
 import com.issueissyu.fe.data.remote.dto.response.location.LocationRegionGroupResponse
 import com.issueissyu.fe.data.remote.dto.response.location.LocationRegionItemResponse
@@ -21,6 +22,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import retrofit2.HttpException
+import java.io.IOException
 import java.util.Locale
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -29,6 +31,7 @@ import kotlin.coroutines.resume
 @Singleton
 class LocationRepositoryImpl @Inject constructor(
     private val locationApi: LocationApi,
+    private val gson: Gson,
     @ApplicationContext private val context: Context,
 ) : LocationRepository {
 
@@ -168,18 +171,63 @@ class LocationRepositoryImpl @Inject constructor(
             if (response.isSuccess) {
                 Result.success(response.result?.address?.takeIf { it.isNotBlank() }.orEmpty())
             } else {
-                Result.failure(Exception(response.message.ifBlank { "이 위치에는 핀을 생성할 수 없습니다." }))
+                Result.failure(
+                    pinCreationAvailabilityException(
+                        code = response.code,
+                        message = response.message,
+                    ),
+                )
             }
         } catch (e: HttpException) {
-            if (e.code() == 403) {
-                Result.failure(Exception("이 위치에는 핀을 생성할 수 없습니다. 다른 위치를 선택해주세요."))
-            } else {
-                Result.failure(e)
-            }
+            val errorEnvelope = e.response()
+                ?.errorBody()
+                ?.string()
+                ?.takeIf { it.isNotBlank() }
+                ?.let { body ->
+                    runCatching { gson.fromJson(body, LocationErrorEnvelope::class.java) }.getOrNull()
+                }
+            Result.failure(
+                pinCreationAvailabilityException(
+                    code = errorEnvelope?.code,
+                    message = errorEnvelope?.message,
+                    httpStatus = e.code(),
+                ),
+            )
+        } catch (e: IOException) {
+            Result.failure(Exception("네트워크 연결을 확인한 뒤 다시 시도해주세요.", e))
         } catch (e: Exception) {
-            Result.failure(e)
+            Result.failure(Exception("핀 생성 가능 여부를 확인하지 못했습니다. 잠시 후 다시 시도해주세요.", e))
         }
     }
+
+    private fun pinCreationAvailabilityException(
+        code: String?,
+        message: String?,
+        httpStatus: Int? = null,
+    ): Exception {
+        val fallbackMessage = when {
+            code == "LOCATION_400_1" || httpStatus == 400 ->
+                "선택한 위치 정보가 올바르지 않습니다. 다른 위치를 선택해주세요."
+            httpStatus == 401 ->
+                "로그인 정보를 확인한 뒤 다시 시도해주세요."
+            httpStatus == 403 ->
+                "현재 위치와 선택한 위치가 너무 멉니다. 가까운 위치를 선택해주세요."
+            code == "LOCATION_404_1" || code == "LOCATION_404_3" || httpStatus == 404 ->
+                "선택한 위치의 주소를 찾을 수 없습니다. 다른 위치를 선택해주세요."
+            code == "LOCATION_502_2" || httpStatus == 502 ->
+                "위치 확인 서비스 연결에 실패했습니다. 잠시 후 다시 시도해주세요."
+            code == "COMMON_500" || httpStatus?.let { it >= 500 } == true ->
+                "일시적인 서버 오류가 발생했습니다. 잠시 후 다시 시도해주세요."
+            else ->
+                "핀 생성 가능 여부를 확인하지 못했습니다. 잠시 후 다시 시도해주세요."
+        }
+        return Exception(message?.takeIf { it.isNotBlank() } ?: fallbackMessage)
+    }
+
+    private data class LocationErrorEnvelope(
+        val code: String = "",
+        val message: String = "",
+    )
 
     override suspend fun getRegionList(): Result<LocationRegions> {
         return try {

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.issueissyu.fe.data.repository
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import android.webkit.MimeTypeMap
 import com.google.gson.Gson
 import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.api.PinApi
@@ -215,12 +216,15 @@ class PinRepositoryImpl @Inject constructor(
             val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
                 ?: throw IllegalArgumentException("첨부한 사진을 읽을 수 없습니다.")
 
-            val mediaType = context.contentResolver.getType(uri)?.toMediaTypeOrNull()
-                ?: "image/*".toMediaType()
+            val fileName = resolveUploadFileName(context, uri)
+            val mimeType = resolveImageMimeType(context, uri, fileName, bytes)
+            val mediaType = mimeType.toMediaTypeOrNull()
+                ?: "image/jpeg".toMediaType()
             val body = bytes.toRequestBody(mediaType)
             MultipartBody.Part.createFormData(
                 name = "photos",
-                filename = "pin_image_${index + 1}",
+                filename = fileName.ensureImageExtensionFromMime(mimeType)
+                    .ifBlank { "pin_image_${index + 1}.jpg" },
                 body = body,
             )
         }
@@ -1085,6 +1089,107 @@ private fun resolveUploadFileName(context: Context, uri: Uri): String {
         ?.substringAfterLast('/')
         ?.takeIf { it.isNotBlank() }
         ?: "problem-solver-photo.jpg"
+}
+
+private fun resolveImageMimeType(
+    context: Context,
+    uri: Uri,
+    fileName: String,
+    bytes: ByteArray,
+): String {
+    val resolverMime = context.contentResolver.getType(uri)
+    if (!resolverMime.isNullOrBlank() && resolverMime != "image/*") {
+        return resolverMime
+    }
+
+    val extension = fileName.substringAfterLast('.', "").lowercase()
+    if (extension.isNotBlank()) {
+        val extensionMime = when (extension) {
+            "jpg", "jpeg" -> "image/jpeg"
+            "png" -> "image/png"
+            "gif" -> "image/gif"
+            "webp" -> "image/webp"
+            "heic" -> "image/heic"
+            "heif" -> "image/heif"
+            else -> MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
+        }
+        if (!extensionMime.isNullOrBlank()) {
+            return extensionMime
+        }
+    }
+
+    val signatureMime = sniffImageMimeType(bytes)
+    if (signatureMime != null) {
+        return signatureMime
+    }
+
+    return "image/jpeg"
+}
+
+private fun sniffImageMimeType(bytes: ByteArray): String? {
+    if (bytes.size >= 3 &&
+        bytes[0] == 0xFF.toByte() &&
+        bytes[1] == 0xD8.toByte() &&
+        bytes[2] == 0xFF.toByte()
+    ) {
+        return "image/jpeg"
+    }
+
+    if (bytes.size >= 8 &&
+        bytes[0] == 0x89.toByte() &&
+        bytes[1] == 0x50.toByte() &&
+        bytes[2] == 0x4E.toByte() &&
+        bytes[3] == 0x47.toByte() &&
+        bytes[4] == 0x0D.toByte() &&
+        bytes[5] == 0x0A.toByte() &&
+        bytes[6] == 0x1A.toByte() &&
+        bytes[7] == 0x0A.toByte()
+    ) {
+        return "image/png"
+    }
+
+    if (bytes.size >= 6) {
+        val header = bytes.copyOfRange(0, 6).decodeToString()
+        if (header == "GIF87a" || header == "GIF89a") {
+            return "image/gif"
+        }
+    }
+
+    if (bytes.size >= 12) {
+        val riff = bytes.copyOfRange(0, 4).decodeToString()
+        val webp = bytes.copyOfRange(8, 12).decodeToString()
+        if (riff == "RIFF" && webp == "WEBP") {
+            return "image/webp"
+        }
+    }
+
+    if (bytes.size >= 12) {
+        val boxType = bytes.copyOfRange(4, 8).decodeToString()
+        if (boxType == "ftyp") {
+            val majorBrand = bytes.copyOfRange(8, 12).decodeToString().lowercase()
+            if (majorBrand.startsWith("hei") || majorBrand.startsWith("hev")) {
+                return "image/heic"
+            }
+            if (majorBrand.startsWith("mif")) {
+                return "image/heif"
+            }
+        }
+    }
+
+    return null
+}
+
+private fun String.ensureImageExtensionFromMime(mimeType: String): String {
+    if (contains('.')) return this
+    val extension = when (mimeType.lowercase()) {
+        "image/png" -> "png"
+        "image/webp" -> "webp"
+        "image/gif" -> "gif"
+        "image/heic" -> "heic"
+        "image/heif" -> "heif"
+        else -> "jpg"
+    }
+    return "$this.$extension"
 }
 
 private fun problemSolverJoinException(code: String, message: String): Exception {

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -24,6 +24,7 @@ import com.issueissyu.fe.data.remote.dto.request.pin.PinCommentsRequest
 import com.issueissyu.fe.data.remote.dto.request.pin.PinDeclarationRequest
 import com.issueissyu.fe.data.remote.dto.request.pin.ApplyPinEmojiRequest
 import com.issueissyu.fe.data.remote.dto.request.pin.CommunicationPinImportRequest
+import com.issueissyu.fe.data.remote.dto.request.pin.IssuePinImportRequest
 import com.issueissyu.fe.data.remote.dto.request.pin.PinImageItemRequest
 import com.issueissyu.fe.data.remote.dto.response.BaseResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.GoNowResponse
@@ -123,16 +124,15 @@ class PinRepositoryImpl @Inject constructor(
 
     override suspend fun createPin(request: CreatePinRequest): Result<Pin> {
         return try {
+            if (request.category == PinCategory.ISSUE && request.imageUris.isEmpty()) {
+                return Result.failure(IllegalArgumentException("이슈 핀은 사진을 최소 1장 첨부해야 합니다."))
+            }
             PinImageUploadValidator.validate(context, request.imageUris).getOrThrow()
             val photos = request.imageUris.toMultipartParts()
             val response = when (request.category) {
                 PinCategory.ISSUE -> aiIssueApiService.createIssuePin(
-                    title = request.title.toTextPart(),
-                    content = request.description.toTextPart(),
-                    tone = request.tone.toTextPart(),
-                    latitude = request.coordinate.latitude.toString().toTextPart(),
-                    longitude = request.coordinate.longitude.toString().toTextPart(),
-                    images = photos,
+                    request = gson.toJson(request.toIssuePinImportRequest()).toJsonPart(),
+                    photos = photos,
                 )
                 PinCategory.COMMUNICATION -> pinApi.createCommunicationPin(
                     request = gson.toJson(request.toCommunicationPinImportRequest()).toJsonPart(),
@@ -169,6 +169,21 @@ class PinRepositoryImpl @Inject constructor(
         )
     }
 
+    private fun CreatePinRequest.toIssuePinImportRequest(): IssuePinImportRequest {
+        val mainUri = mainImageUri?.takeIf { imageUris.contains(it) } ?: imageUris.firstOrNull()
+        val pinImages = imageUris.takeIf { it.isNotEmpty() }?.map { uri ->
+            PinImageItemRequest(isMain = uri == mainUri)
+        }
+
+        return IssuePinImportRequest(
+            lat = coordinate.latitude,
+            lng = coordinate.longitude,
+            pinTitle = title,
+            pinContent = description,
+            pinImages = pinImages,
+        )
+    }
+
     private fun BaseResponse<PinImportResponse?>.toCreatedPin(request: CreatePinRequest): Pin {
         val result = result
         val detail = when (request.category) {
@@ -191,8 +206,6 @@ class PinRepositoryImpl @Inject constructor(
             detail = detail,
         )
     }
-
-    private fun String.toTextPart(): RequestBody = toRequestBody("text/plain".toMediaType())
 
     private fun String.toJsonPart(): RequestBody = toRequestBody("application/json".toMediaType())
 

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -3,6 +3,8 @@ package com.issueissyu.fe.data.repository
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
+import com.google.gson.Gson
+import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.api.PinApi
 import com.issueissyu.fe.data.remote.dto.pin.toPinSolveInfo
 import com.issueissyu.fe.data.remote.dto.pin.toPetitionJoinInfo
@@ -21,12 +23,15 @@ import com.issueissyu.fe.data.remote.dto.pin.toUnsupportedPinTypeMessage
 import com.issueissyu.fe.data.remote.dto.request.pin.PinCommentsRequest
 import com.issueissyu.fe.data.remote.dto.request.pin.PinDeclarationRequest
 import com.issueissyu.fe.data.remote.dto.request.pin.ApplyPinEmojiRequest
+import com.issueissyu.fe.data.remote.dto.request.pin.CommunicationPinImportRequest
+import com.issueissyu.fe.data.remote.dto.request.pin.PinImageItemRequest
 import com.issueissyu.fe.data.remote.dto.response.BaseResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.GoNowResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.PetitionStatusResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.PetitionSubmitResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.PinEmojiDto
 import com.issueissyu.fe.data.remote.dto.response.pin.PinEmojisResponse
+import com.issueissyu.fe.data.remote.dto.response.pin.PinImportResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.PinLikeResponse
 import com.issueissyu.fe.data.remote.dto.response.pin.PinSolveResponse
 import com.issueissyu.fe.core.time.parseFlexibleDateTimeToEpochMilli
@@ -68,7 +73,9 @@ import com.issueissyu.fe.domain.repository.PinRepository
 import java.io.File
 import java.util.UUID
 import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
+import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
@@ -76,8 +83,15 @@ import kotlinx.coroutines.withContext
 @Singleton
 class PinRepositoryImpl @Inject constructor(
     private val pinApi: PinApi,
+    private val aiIssueApiService: AiIssueApiService,
+    private val gson: Gson,
     @ApplicationContext private val context: Context,
 ) : PinRepository {
+
+    private companion object {
+        const val MAX_PIN_IMAGE_COUNT = 5
+        const val MAX_TOTAL_PIN_IMAGE_BYTES = 45L * 1024L * 1024L
+    }
 
     // TODO: 실제 백엔드와 연결 시 PinSamples 의존을 제거하고 네트워크 호출 로직으로 대체.
     private val dummyPins: MutableList<Pin> = PinSamples.pins.toMutableList()
@@ -110,30 +124,104 @@ class PinRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun createPin(request: CreatePinRequest): Pin {
-        val newPinDetail: PinDetail = when (request.category) {
+    override suspend fun createPin(request: CreatePinRequest): Result<Pin> {
+        return try {
+            val photos = request.imageUris.toMultipartParts()
+            val response = when (request.category) {
+                PinCategory.ISSUE -> aiIssueApiService.createIssuePin(
+                    title = request.title.toTextPart(),
+                    content = request.description.toTextPart(),
+                    tone = request.tone.toTextPart(),
+                    latitude = request.coordinate.latitude.toString().toTextPart(),
+                    longitude = request.coordinate.longitude.toString().toTextPart(),
+                    images = photos,
+                )
+                PinCategory.COMMUNICATION -> pinApi.createCommunicationPin(
+                    request = gson.toJson(request.toCommunicationPinImportRequest()).toJsonPart(),
+                    photos = photos,
+                )
+                PinCategory.SHOP,
+                PinCategory.FESTIVAL -> return Result.failure(
+                    IllegalArgumentException("가게와 축제 핀은 일반 사용자가 생성할 수 없습니다."),
+                )
+            }
+
+            if (response.isSuccess) {
+                Result.success(response.toCreatedPin(request))
+            } else {
+                Result.failure(Exception(response.message.ifBlank { "핀 생성에 실패했습니다." }))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    private fun CreatePinRequest.toCommunicationPinImportRequest(): CommunicationPinImportRequest {
+        return CommunicationPinImportRequest(
+            lat = coordinate.latitude,
+            lng = coordinate.longitude,
+            pinImageUrls = imageUris.mapIndexed { index, _ ->
+                PinImageItemRequest(
+                    pinImageUrl = "",
+                    isMain = index == 0,
+                )
+            },
+            pinTitle = title,
+            pinContent = description,
+        )
+    }
+
+    private fun BaseResponse<PinImportResponse?>.toCreatedPin(request: CreatePinRequest): Pin {
+        val result = result
+        val detail = when (request.category) {
             PinCategory.ISSUE -> IssuePinDetail(writer = currentUser)
             PinCategory.COMMUNICATION -> CommunicationPinDetail(writer = currentUser)
-            PinCategory.SHOP, PinCategory.FESTIVAL -> throw IllegalArgumentException("Shop and Festival pins cannot be created by users.")
+            PinCategory.SHOP, PinCategory.FESTIVAL -> error("Unsupported created pin category.")
         }
-
-        val newPin = Pin(
-            id = UUID.randomUUID().toString(), // 새 핀은 UUID로 생성
+        return Pin(
+            id = result?.pinId?.takeIf { it > 0 }?.toString() ?: UUID.randomUUID().toString(),
             title = request.title,
             description = request.description,
             coordinate = request.coordinate,
-            address = request.address,
+            address = result?.pinDetailAddress?.takeIf { it.isNotBlank() } ?: request.address,
             locationName = request.locationName,
             neighborhoodId = request.neighborhoodId,
-            neighborhoodName = request.neighborhoodName,
-            imageUrls = request.imageUrls,
-            createdAt = Instant.now().toString(),
-            updatedAt = null,
-            detail = newPinDetail
+            neighborhoodName = result?.region ?: request.neighborhoodName,
+            imageUrls = result?.pinImageUrls.orEmpty().mapNotNull { it.pinImageUrl.takeIf { url -> url.isNotBlank() } },
+            createdAt = result?.createdAt ?: Instant.now().toString(),
+            updatedAt = result?.updatedAt,
+            detail = detail,
         )
-        // TODO: 실제 백엔드 API를 호출하여 핀을 생성하고, 서버로부터 반환된 실제 Pin 객체를 사용해야 합니다.
-        dummyPins.add(newPin)
-        return newPin
+    }
+
+    private fun String.toTextPart(): RequestBody = toRequestBody("text/plain".toMediaType())
+
+    private fun String.toJsonPart(): RequestBody = toRequestBody("application/json".toMediaType())
+
+    private fun List<String>.toMultipartParts(): List<MultipartBody.Part> {
+        if (size > MAX_PIN_IMAGE_COUNT) {
+            throw IllegalArgumentException("사진은 최대 ${MAX_PIN_IMAGE_COUNT}장까지 첨부할 수 있습니다.")
+        }
+
+        var totalBytes = 0L
+        return mapIndexed { index, uriString ->
+            val uri = Uri.parse(uriString)
+            val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
+                ?: throw IllegalArgumentException("첨부한 사진을 읽을 수 없습니다.")
+            totalBytes += bytes.size
+            if (totalBytes > MAX_TOTAL_PIN_IMAGE_BYTES) {
+                throw IllegalArgumentException("사진 전체 용량은 45MB를 넘을 수 없습니다.")
+            }
+
+            val mediaType = context.contentResolver.getType(uri)?.toMediaTypeOrNull()
+                ?: "image/*".toMediaType()
+            val body = bytes.toRequestBody(mediaType)
+            MultipartBody.Part.createFormData(
+                name = "photos",
+                filename = "pin_image_${index + 1}",
+                body = body,
+            )
+        }
     }
 
     override suspend fun updatePin(pinId: String, request: UpdatePinRequest): Pin {

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -136,6 +136,12 @@ class PinRepositoryImpl @Inject constructor(
             PinImageUploadValidator.validate(context, request.imageUris).getOrThrow()
             val multipart = request.imageUris.toMultipartParts()
             uploadMetas = multipart.uploadMetas
+            if (uploadMetas.isNotEmpty()) {
+                PinImageUploadDiagnostics.logUploadPrepare(
+                    category = request.category.name,
+                    metas = uploadMetas,
+                )
+            }
             val response = when (request.category) {
                 PinCategory.ISSUE -> aiIssueApiService.createIssuePin(
                     request = gson.toJson(request.toIssuePinImportRequest()).toJsonPart(),
@@ -303,9 +309,13 @@ class PinRepositoryImpl @Inject constructor(
                 uriScheme = uri.scheme.orEmpty(),
                 bytes = bytes,
             )
+            val uploadFilename = PinImageMimeResolver.ensureExtension(fileName, mimeResolution.mimeType)
+                .ifBlank { "pin_image_${index + 1}.jpg" }
             uploadMetas += PinImageUploadMeta(
                 uriScheme = uri.scheme.orEmpty(),
                 fileName = fileName,
+                uploadFilename = uploadFilename,
+                byteSize = bytes.size,
                 resolvedMime = mimeResolution.mimeType,
                 mimeSource = mimeResolution.source,
                 contentResolverMime = mimeResolution.contentResolverMime,
@@ -313,12 +323,10 @@ class PinRepositoryImpl @Inject constructor(
             )
             val mediaType = mimeResolution.mimeType.toMediaTypeOrNull()
                 ?: "image/jpeg".toMediaType()
-            val body = bytes.toRequestBody(mediaType)
             parts += MultipartBody.Part.createFormData(
                 name = "photos",
-                filename = PinImageMimeResolver.ensureExtension(fileName, mimeResolution.mimeType)
-                    .ifBlank { "pin_image_${index + 1}.jpg" },
-                body = body,
+                filename = uploadFilename,
+                body = bytes.toRequestBody(mediaType),
             )
         }
         return PinMultipartUpload(parts = parts, uploadMetas = uploadMetas)

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -127,11 +127,11 @@ class PinRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun createPin(request: CreatePinRequest): Result<Pin> {
+    override suspend fun createPin(request: CreatePinRequest): Result<Pin> = withContext(Dispatchers.IO) {
         var uploadMetas = emptyList<PinImageUploadMeta>()
-        return try {
+        try {
             if (request.category == PinCategory.ISSUE && request.imageUris.isEmpty()) {
-                return Result.failure(IllegalArgumentException("이슈 핀은 사진을 최소 1장 첨부해야 합니다."))
+                return@withContext Result.failure(IllegalArgumentException("이슈 핀은 사진을 최소 1장 첨부해야 합니다."))
             }
             PinImageUploadValidator.validate(context, request.imageUris).getOrThrow()
             val multipart = request.imageUris.toMultipartParts()
@@ -152,7 +152,7 @@ class PinRepositoryImpl @Inject constructor(
                     photos = multipart.parts,
                 )
                 PinCategory.SHOP,
-                PinCategory.FESTIVAL -> return Result.failure(
+                PinCategory.FESTIVAL -> return@withContext Result.failure(
                     IllegalArgumentException("가게와 축제 핀은 일반 사용자가 생성할 수 없습니다."),
                 )
             }

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -69,6 +69,8 @@ import com.issueissyu.fe.domain.model.pin.UpdatePinRequest
 import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
+import com.issueissyu.fe.core.constants.PinImageUploadConstraints
+import com.issueissyu.fe.core.media.PinImageUploadValidator
 import com.issueissyu.fe.domain.repository.PinRepository
 import java.io.File
 import java.util.UUID
@@ -87,11 +89,6 @@ class PinRepositoryImpl @Inject constructor(
     private val gson: Gson,
     @ApplicationContext private val context: Context,
 ) : PinRepository {
-
-    private companion object {
-        const val MAX_PIN_IMAGE_COUNT = 5
-        const val MAX_TOTAL_PIN_IMAGE_BYTES = 45L * 1024L * 1024L
-    }
 
     // TODO: 실제 백엔드와 연결 시 PinSamples 의존을 제거하고 네트워크 호출 로직으로 대체.
     private val dummyPins: MutableList<Pin> = PinSamples.pins.toMutableList()
@@ -126,6 +123,7 @@ class PinRepositoryImpl @Inject constructor(
 
     override suspend fun createPin(request: CreatePinRequest): Result<Pin> {
         return try {
+            PinImageUploadValidator.validate(context, request.imageUris).getOrThrow()
             val photos = request.imageUris.toMultipartParts()
             val response = when (request.category) {
                 PinCategory.ISSUE -> aiIssueApiService.createIssuePin(
@@ -157,15 +155,15 @@ class PinRepositoryImpl @Inject constructor(
     }
 
     private fun CreatePinRequest.toCommunicationPinImportRequest(): CommunicationPinImportRequest {
+        val mainUri = mainImageUri?.takeIf { imageUris.contains(it) } ?: imageUris.firstOrNull()
+        val pinImages = imageUris.takeIf { it.isNotEmpty() }?.map { uri ->
+            PinImageItemRequest(isMain = uri == mainUri)
+        }
+
         return CommunicationPinImportRequest(
             lat = coordinate.latitude,
             lng = coordinate.longitude,
-            pinImageUrls = imageUris.mapIndexed { index, _ ->
-                PinImageItemRequest(
-                    pinImageUrl = "",
-                    isMain = index == 0,
-                )
-            },
+            pinImages = pinImages,
             pinTitle = title,
             pinContent = description,
         )
@@ -199,19 +197,10 @@ class PinRepositoryImpl @Inject constructor(
     private fun String.toJsonPart(): RequestBody = toRequestBody("application/json".toMediaType())
 
     private fun List<String>.toMultipartParts(): List<MultipartBody.Part> {
-        if (size > MAX_PIN_IMAGE_COUNT) {
-            throw IllegalArgumentException("사진은 최대 ${MAX_PIN_IMAGE_COUNT}장까지 첨부할 수 있습니다.")
-        }
-
-        var totalBytes = 0L
         return mapIndexed { index, uriString ->
             val uri = Uri.parse(uriString)
             val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
                 ?: throw IllegalArgumentException("첨부한 사진을 읽을 수 없습니다.")
-            totalBytes += bytes.size
-            if (totalBytes > MAX_TOTAL_PIN_IMAGE_BYTES) {
-                throw IllegalArgumentException("사진 전체 용량은 45MB를 넘을 수 없습니다.")
-            }
 
             val mediaType = context.contentResolver.getType(uri)?.toMediaTypeOrNull()
                 ?: "image/*".toMediaType()

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -3,7 +3,6 @@ package com.issueissyu.fe.data.repository
 import android.content.Context
 import android.net.Uri
 import android.provider.OpenableColumns
-import android.webkit.MimeTypeMap
 import com.google.gson.Gson
 import com.issueissyu.fe.data.remote.api.AiIssueApiService
 import com.issueissyu.fe.data.remote.api.PinApi
@@ -72,7 +71,11 @@ import java.time.Instant
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import com.issueissyu.fe.core.constants.PinImageUploadConstraints
+import com.issueissyu.fe.core.media.PinImageMimeResolver
+import com.issueissyu.fe.core.media.PinImageUploadDiagnostics
+import com.issueissyu.fe.core.media.PinImageUploadMeta
 import com.issueissyu.fe.core.media.PinImageUploadValidator
+import com.issueissyu.fe.domain.model.pin.PinCreateException
 import com.issueissyu.fe.domain.repository.PinRepository
 import java.io.File
 import java.util.UUID
@@ -83,6 +86,7 @@ import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import retrofit2.HttpException
 
 @Singleton
 class PinRepositoryImpl @Inject constructor(
@@ -124,20 +128,22 @@ class PinRepositoryImpl @Inject constructor(
     }
 
     override suspend fun createPin(request: CreatePinRequest): Result<Pin> {
+        var uploadMetas = emptyList<PinImageUploadMeta>()
         return try {
             if (request.category == PinCategory.ISSUE && request.imageUris.isEmpty()) {
                 return Result.failure(IllegalArgumentException("이슈 핀은 사진을 최소 1장 첨부해야 합니다."))
             }
             PinImageUploadValidator.validate(context, request.imageUris).getOrThrow()
-            val photos = request.imageUris.toMultipartParts()
+            val multipart = request.imageUris.toMultipartParts()
+            uploadMetas = multipart.uploadMetas
             val response = when (request.category) {
                 PinCategory.ISSUE -> aiIssueApiService.createIssuePin(
                     request = gson.toJson(request.toIssuePinImportRequest()).toJsonPart(),
-                    photos = photos,
+                    photos = multipart.parts,
                 )
                 PinCategory.COMMUNICATION -> pinApi.createCommunicationPin(
                     request = gson.toJson(request.toCommunicationPinImportRequest()).toJsonPart(),
-                    photos = photos,
+                    photos = multipart.parts,
                 )
                 PinCategory.SHOP,
                 PinCategory.FESTIVAL -> return Result.failure(
@@ -148,11 +154,79 @@ class PinRepositoryImpl @Inject constructor(
             if (response.isSuccess) {
                 Result.success(response.toCreatedPin(request))
             } else {
-                Result.failure(Exception(response.message.ifBlank { "핀 생성에 실패했습니다." }))
+                if (request.imageUris.isNotEmpty()) {
+                    PinImageUploadDiagnostics.logUploadFailure(
+                        httpStatus = null,
+                        serverCode = response.code,
+                        metas = uploadMetas,
+                    )
+                }
+                Result.failure(
+                    toPinCreateException(
+                        code = response.code,
+                        message = response.message,
+                    ),
+                )
             }
+        } catch (e: HttpException) {
+            val errorEnvelope = e.response()?.errorBody()?.string()
+                ?.let { body -> runCatching { gson.fromJson(body, PinCreateErrorEnvelope::class.java) }.getOrNull() }
+            if (request.imageUris.isNotEmpty()) {
+                PinImageUploadDiagnostics.logUploadFailure(
+                    httpStatus = e.code(),
+                    serverCode = errorEnvelope?.code,
+                    metas = uploadMetas,
+                )
+            }
+            Result.failure(
+                toPinCreateException(
+                    code = errorEnvelope?.code,
+                    message = errorEnvelope?.message ?: e.message(),
+                    fallbackMessage = "핀 생성에 실패했습니다.",
+                ),
+            )
         } catch (e: Exception) {
+            if (request.imageUris.isNotEmpty() && uploadMetas.isNotEmpty()) {
+                PinImageUploadDiagnostics.logUploadFailure(
+                    httpStatus = null,
+                    serverCode = e.javaClass.simpleName,
+                    metas = uploadMetas,
+                )
+            }
             Result.failure(e)
         }
+    }
+
+    private data class PinCreateErrorEnvelope(
+        val code: String = "",
+        val message: String = "",
+    )
+
+    private data class PinMultipartUpload(
+        val parts: List<MultipartBody.Part>,
+        val uploadMetas: List<PinImageUploadMeta>,
+    )
+
+    private fun toPinCreateException(
+        code: String?,
+        message: String?,
+        fallbackMessage: String = "핀 생성에 실패했습니다.",
+    ): PinCreateException {
+        val normalizedCode = code?.takeIf { it.isNotBlank() }
+        val normalizedMessage = message?.takeIf { it.isNotBlank() }
+        val isImageRelated = normalizedCode?.startsWith("PIN_IMAGE") == true
+        val userMessage = when (normalizedCode) {
+            "PIN_IMAGE_400_2" ->
+                normalizedMessage?.ifBlank { null }
+                    ?: "사진 첨부에 실패했습니다. 다른 사진으로 다시 시도해주세요."
+            else ->
+                normalizedMessage ?: fallbackMessage
+        }
+        return PinCreateException(
+            message = userMessage,
+            isImageRelated = isImageRelated,
+            serverCode = normalizedCode,
+        )
     }
 
     private fun CreatePinRequest.toCommunicationPinImportRequest(): CommunicationPinImportRequest {
@@ -210,24 +284,41 @@ class PinRepositoryImpl @Inject constructor(
 
     private fun String.toJsonPart(): RequestBody = toRequestBody("application/json".toMediaType())
 
-    private fun List<String>.toMultipartParts(): List<MultipartBody.Part> {
-        return mapIndexed { index, uriString ->
+    private fun List<String>.toMultipartParts(): PinMultipartUpload {
+        val parts = mutableListOf<MultipartBody.Part>()
+        val uploadMetas = mutableListOf<PinImageUploadMeta>()
+        forEachIndexed { index, uriString ->
             val uri = Uri.parse(uriString)
             val bytes = context.contentResolver.openInputStream(uri)?.use { it.readBytes() }
                 ?: throw IllegalArgumentException("첨부한 사진을 읽을 수 없습니다.")
 
             val fileName = resolveUploadFileName(context, uri)
-            val mimeType = resolveImageMimeType(context, uri, fileName, bytes)
-            val mediaType = mimeType.toMediaTypeOrNull()
+            val mimeResolution = PinImageMimeResolver.resolve(context, uri, fileName, bytes)
+            PinImageUploadDiagnostics.logMimeFallback(
+                resolution = mimeResolution,
+                fileName = fileName,
+                uriScheme = uri.scheme.orEmpty(),
+                bytes = bytes,
+            )
+            uploadMetas += PinImageUploadMeta(
+                uriScheme = uri.scheme.orEmpty(),
+                fileName = fileName,
+                resolvedMime = mimeResolution.mimeType,
+                mimeSource = mimeResolution.source,
+                contentResolverMime = mimeResolution.contentResolverMime,
+                header = PinImageUploadDiagnostics.formatHeaderHex(bytes),
+            )
+            val mediaType = mimeResolution.mimeType.toMediaTypeOrNull()
                 ?: "image/jpeg".toMediaType()
             val body = bytes.toRequestBody(mediaType)
-            MultipartBody.Part.createFormData(
+            parts += MultipartBody.Part.createFormData(
                 name = "photos",
-                filename = fileName.ensureImageExtensionFromMime(mimeType)
+                filename = PinImageMimeResolver.ensureExtension(fileName, mimeResolution.mimeType)
                     .ifBlank { "pin_image_${index + 1}.jpg" },
                 body = body,
             )
         }
+        return PinMultipartUpload(parts = parts, uploadMetas = uploadMetas)
     }
 
     override suspend fun updatePin(pinId: String, request: UpdatePinRequest): Pin {
@@ -1089,107 +1180,6 @@ private fun resolveUploadFileName(context: Context, uri: Uri): String {
         ?.substringAfterLast('/')
         ?.takeIf { it.isNotBlank() }
         ?: "problem-solver-photo.jpg"
-}
-
-private fun resolveImageMimeType(
-    context: Context,
-    uri: Uri,
-    fileName: String,
-    bytes: ByteArray,
-): String {
-    val resolverMime = context.contentResolver.getType(uri)
-    if (!resolverMime.isNullOrBlank() && resolverMime != "image/*") {
-        return resolverMime
-    }
-
-    val extension = fileName.substringAfterLast('.', "").lowercase()
-    if (extension.isNotBlank()) {
-        val extensionMime = when (extension) {
-            "jpg", "jpeg" -> "image/jpeg"
-            "png" -> "image/png"
-            "gif" -> "image/gif"
-            "webp" -> "image/webp"
-            "heic" -> "image/heic"
-            "heif" -> "image/heif"
-            else -> MimeTypeMap.getSingleton().getMimeTypeFromExtension(extension)
-        }
-        if (!extensionMime.isNullOrBlank()) {
-            return extensionMime
-        }
-    }
-
-    val signatureMime = sniffImageMimeType(bytes)
-    if (signatureMime != null) {
-        return signatureMime
-    }
-
-    return "image/jpeg"
-}
-
-private fun sniffImageMimeType(bytes: ByteArray): String? {
-    if (bytes.size >= 3 &&
-        bytes[0] == 0xFF.toByte() &&
-        bytes[1] == 0xD8.toByte() &&
-        bytes[2] == 0xFF.toByte()
-    ) {
-        return "image/jpeg"
-    }
-
-    if (bytes.size >= 8 &&
-        bytes[0] == 0x89.toByte() &&
-        bytes[1] == 0x50.toByte() &&
-        bytes[2] == 0x4E.toByte() &&
-        bytes[3] == 0x47.toByte() &&
-        bytes[4] == 0x0D.toByte() &&
-        bytes[5] == 0x0A.toByte() &&
-        bytes[6] == 0x1A.toByte() &&
-        bytes[7] == 0x0A.toByte()
-    ) {
-        return "image/png"
-    }
-
-    if (bytes.size >= 6) {
-        val header = bytes.copyOfRange(0, 6).decodeToString()
-        if (header == "GIF87a" || header == "GIF89a") {
-            return "image/gif"
-        }
-    }
-
-    if (bytes.size >= 12) {
-        val riff = bytes.copyOfRange(0, 4).decodeToString()
-        val webp = bytes.copyOfRange(8, 12).decodeToString()
-        if (riff == "RIFF" && webp == "WEBP") {
-            return "image/webp"
-        }
-    }
-
-    if (bytes.size >= 12) {
-        val boxType = bytes.copyOfRange(4, 8).decodeToString()
-        if (boxType == "ftyp") {
-            val majorBrand = bytes.copyOfRange(8, 12).decodeToString().lowercase()
-            if (majorBrand.startsWith("hei") || majorBrand.startsWith("hev")) {
-                return "image/heic"
-            }
-            if (majorBrand.startsWith("mif")) {
-                return "image/heif"
-            }
-        }
-    }
-
-    return null
-}
-
-private fun String.ensureImageExtensionFromMime(mimeType: String): String {
-    if (contains('.')) return this
-    val extension = when (mimeType.lowercase()) {
-        "image/png" -> "png"
-        "image/webp" -> "webp"
-        "image/gif" -> "gif"
-        "image/heic" -> "heic"
-        "image/heif" -> "heif"
-        else -> "jpg"
-    }
-    return "$this.$extension"
 }
 
 private fun problemSolverJoinException(code: String, message: String): Exception {

--- a/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
+++ b/app/src/main/java/com/issueissyu/fe/data/repository/PinRepositoryImpl.kt
@@ -159,6 +159,7 @@ class PinRepositoryImpl @Inject constructor(
                         httpStatus = null,
                         serverCode = response.code,
                         metas = uploadMetas,
+                        responseBody = gson.toJson(response),
                     )
                 }
                 Result.failure(
@@ -169,13 +170,15 @@ class PinRepositoryImpl @Inject constructor(
                 )
             }
         } catch (e: HttpException) {
-            val errorEnvelope = e.response()?.errorBody()?.string()
+            val rawBody = e.response()?.errorBody()?.string().orEmpty()
+            val errorEnvelope = rawBody.takeIf { it.isNotBlank() }
                 ?.let { body -> runCatching { gson.fromJson(body, PinCreateErrorEnvelope::class.java) }.getOrNull() }
             if (request.imageUris.isNotEmpty()) {
                 PinImageUploadDiagnostics.logUploadFailure(
                     httpStatus = e.code(),
                     serverCode = errorEnvelope?.code,
                     metas = uploadMetas,
+                    responseBody = rawBody.takeIf { it.isNotBlank() },
                 )
             }
             Result.failure(

--- a/app/src/main/java/com/issueissyu/fe/di/network/NetworkModule.kt
+++ b/app/src/main/java/com/issueissyu/fe/di/network/NetworkModule.kt
@@ -20,12 +20,15 @@ import okhttp3.OkHttpClient
 import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
+import java.util.concurrent.TimeUnit
 import javax.inject.Named
 import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
 object NetworkModule {
+
+    private const val AI_TIMEOUT_SECONDS = 60L
     @Provides
     @Singleton
     fun provideGson(): Gson = Gson()
@@ -80,8 +83,30 @@ object NetworkModule {
     @Provides
     @Singleton
     @Named("ai")
+    fun provideAiOkHttpClient(
+        loggingInterceptor: HttpLoggingInterceptor,
+        authInterceptor: AuthInterceptor,
+        tokenAuthenticator: TokenAuthenticator,
+    ): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(AI_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(AI_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .writeTimeout(AI_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .addInterceptor(authInterceptor)
+            .apply {
+                if (BuildConfig.DEBUG) {
+                    addInterceptor(loggingInterceptor)
+                }
+            }
+            .authenticator(tokenAuthenticator)
+            .build()
+    }
+
+    @Provides
+    @Singleton
+    @Named("ai")
     fun provideAiRetrofit(
-        okHttpClient: OkHttpClient,
+        @Named("ai") okHttpClient: OkHttpClient,
         gson: Gson,
     ): Retrofit {
         return Retrofit.Builder()

--- a/app/src/main/java/com/issueissyu/fe/domain/model/issue/IssueAiDraft.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/model/issue/IssueAiDraft.kt
@@ -1,0 +1,6 @@
+package com.issueissyu.fe.domain.model.issue
+
+data class IssueAiDraft(
+    val title: String?,
+    val content: String?,
+)

--- a/app/src/main/java/com/issueissyu/fe/domain/model/issue/IssueToneType.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/model/issue/IssueToneType.kt
@@ -1,0 +1,6 @@
+package com.issueissyu.fe.domain.model.issue
+
+data class IssueToneType(
+    val key: String?,
+    val label: String,
+)

--- a/app/src/main/java/com/issueissyu/fe/domain/model/pin/PinCreateException.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/model/pin/PinCreateException.kt
@@ -1,0 +1,7 @@
+package com.issueissyu.fe.domain.model.pin
+
+class PinCreateException(
+    message: String,
+    val isImageRelated: Boolean = false,
+    val serverCode: String? = null,
+) : Exception(message)

--- a/app/src/main/java/com/issueissyu/fe/domain/model/pin/PinModels.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/model/pin/PinModels.kt
@@ -338,6 +338,7 @@ data class CreatePinRequest(
     val neighborhoodId: String? = null,
     val neighborhoodName: String? = null,
     val imageUris: List<String> = emptyList(),
+    val mainImageUri: String? = null,
     val imageUrls: List<String> = emptyList(),
     val tone: String = "없음",
 )

--- a/app/src/main/java/com/issueissyu/fe/domain/model/pin/PinModels.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/model/pin/PinModels.kt
@@ -337,7 +337,9 @@ data class CreatePinRequest(
     val locationName: String? = null,
     val neighborhoodId: String? = null,
     val neighborhoodName: String? = null,
-    val imageUrls: List<String> = emptyList()
+    val imageUris: List<String> = emptyList(),
+    val imageUrls: List<String> = emptyList(),
+    val tone: String = "없음",
 )
 
 data class UpdatePinRequest(

--- a/app/src/main/java/com/issueissyu/fe/domain/repository/IssueRepository.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/repository/IssueRepository.kt
@@ -2,9 +2,12 @@ package com.issueissyu.fe.domain.repository
 
 import com.issueissyu.fe.domain.model.issue.IssueAiDraft
 import com.issueissyu.fe.domain.model.issue.IssueReliability
+import com.issueissyu.fe.domain.model.issue.IssueToneType
 
 interface IssueRepository {
     // suspend fun getIssues(): Flow<List<Issue>>
+    suspend fun getIssueToneTypes(): Result<List<IssueToneType>>
+
     suspend fun createIssueAiDraft(
         title: String,
         content: String,

--- a/app/src/main/java/com/issueissyu/fe/domain/repository/IssueRepository.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/repository/IssueRepository.kt
@@ -1,8 +1,17 @@
 package com.issueissyu.fe.domain.repository
 
+import com.issueissyu.fe.domain.model.issue.IssueAiDraft
 import com.issueissyu.fe.domain.model.issue.IssueReliability
 
 interface IssueRepository {
     // suspend fun getIssues(): Flow<List<Issue>>
+    suspend fun createIssueAiDraft(
+        title: String,
+        content: String,
+        tone: String,
+        latitude: Double,
+        longitude: Double,
+    ): Result<IssueAiDraft>
+
     suspend fun getIssueReliability(pinId: Long): Result<IssueReliability>
 }

--- a/app/src/main/java/com/issueissyu/fe/domain/repository/PinRepository.kt
+++ b/app/src/main/java/com/issueissyu/fe/domain/repository/PinRepository.kt
@@ -28,7 +28,7 @@ interface PinRepository {
     suspend fun getIssuePins(): List<Pin>
     suspend fun getCommunityPins(): List<Pin>
     suspend fun getMyPins(): List<Pin>
-    suspend fun createPin(request: CreatePinRequest): Pin
+    suspend fun createPin(request: CreatePinRequest): Result<Pin>
     suspend fun updatePin(pinId: String, request: UpdatePinRequest): Pin
 
     suspend fun getMapPinsInBounds(bounds: MapBounds): List<MapPinMarker>

--- a/app/src/main/java/com/issueissyu/fe/ui/IssueissyuApp.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/IssueissyuApp.kt
@@ -3,6 +3,9 @@ package com.issueissyu.fe.ui
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.issueissyu.fe.ui.components.BottomNavigationBar
@@ -27,10 +30,11 @@ fun App() {
     val navController = rememberNavController()
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = navBackStackEntry?.destination?.route
+    var isMapLocationSelectionMode by remember { mutableStateOf(false) }
 
     Scaffold(
         bottomBar = {
-            if (shouldShowBottomBar(currentRoute)) {
+            if (shouldShowBottomBar(currentRoute) && !isMapLocationSelectionMode) {
                 BottomNavigationBar(
                     navController = navController,
                     currentRoute = currentRoute
@@ -40,7 +44,8 @@ fun App() {
     ) { paddingValues ->
         AppNavGraph(
             navController = navController,
-            paddingValues = paddingValues
+            paddingValues = paddingValues,
+            onMapLocationSelectionModeChanged = { isMapLocationSelectionMode = it },
         )
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/ui/components/PhotoAddSourceBottomSheet.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/components/PhotoAddSourceBottomSheet.kt
@@ -1,0 +1,96 @@
+package com.issueissyu.fe.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PhotoLibrary
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import com.issueissyu.fe.ui.theme.Gray_5
+import com.issueissyu.fe.ui.theme.IssueTypo
+import com.issueissyu.fe.ui.theme.Text as TextColor
+import com.issueissyu.fe.ui.theme.Title
+import com.issueissyu.fe.ui.theme.White
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PhotoAddSourceBottomSheet(
+    onDismissRequest: () -> Unit,
+    onAlbumClick: () -> Unit,
+    onCameraClick: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        containerColor = White,
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        dragHandle = null,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "사진 추가",
+                style = IssueTypo.Bold18.copy(color = Title),
+            )
+            PhotoSourceOptionRow(
+                icon = Icons.Default.PhotoLibrary,
+                label = "앨범에서 선택",
+                onClick = onAlbumClick,
+            )
+            PhotoSourceOptionRow(
+                icon = Icons.Default.PhotoCamera,
+                label = "카메라로 촬영",
+                onClick = onCameraClick,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun PhotoSourceOptionRow(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Gray_5,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = label,
+            style = IssueTypo.Regular15.copy(color = TextColor),
+        )
+    }
+}

--- a/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
@@ -44,6 +44,8 @@ import com.issueissyu.fe.ui.screens.pindetail.ReportTargetType
 import com.issueissyu.fe.ui.screens.community.CommunityScreen
 import com.issueissyu.fe.ui.screens.community.detail.CommunityDetailScreen
 import com.issueissyu.fe.ui.screens.community.detail.COMMUNITY_DETAIL_REFRESH_KEY
+import com.issueissyu.fe.ui.screens.map.PIN_CREATE_FOCUS_PIN_ID_KEY
+import com.issueissyu.fe.ui.screens.map.PIN_CREATE_MAP_REFRESH_KEY
 
 @Composable
 fun AppNavGraph(
@@ -200,6 +202,7 @@ fun AppNavGraph(
                 MapScreen(
                     navController = navController,
                     focusPinId = backStackEntry.arguments?.getString("focusPinId"),
+                    savedStateHandle = backStackEntry.savedStateHandle,
                 )
             }
         }
@@ -406,7 +409,16 @@ fun AppNavGraph(
                         userLat = userLat,
                         userLng = userLng,
                         address = address,
-                        onBackClick = { navController.popBackStack() }
+                        onBackClick = { navController.popBackStack() },
+                        onCreated = { pinId ->
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(PIN_CREATE_MAP_REFRESH_KEY, true)
+                            navController.previousBackStackEntry
+                                ?.savedStateHandle
+                                ?.set(PIN_CREATE_FOCUS_PIN_ID_KEY, pinId)
+                            navController.popBackStack()
+                        },
                     )
                 }
             }

--- a/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
@@ -1,5 +1,6 @@
 package com.issueissyu.fe.ui.navigation
 
+import android.net.Uri
 import android.widget.Toast
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Box
@@ -342,7 +343,7 @@ fun AppNavGraph(
             }
         }
         composable(
-            route = "${AppDestinations.PIN_CREATION_ROUTE}?type={type}&pinLat={pinLat}&pinLng={pinLng}&userLat={userLat}&userLng={userLng}",
+            route = "${AppDestinations.PIN_CREATION_ROUTE}?type={type}&pinLat={pinLat}&pinLng={pinLng}&userLat={userLat}&userLng={userLng}&address={address}",
             arguments = listOf(
                 navArgument("type") {
                     type = NavType.StringType
@@ -363,6 +364,10 @@ fun AppNavGraph(
                 navArgument("userLng") {
                     type = NavType.FloatType
                     defaultValue = 0f
+                },
+                navArgument("address") {
+                    type = NavType.StringType
+                    defaultValue = ""
                 }
             )
         ) { backStackEntry ->
@@ -373,6 +378,7 @@ fun AppNavGraph(
             val pinLng = (backStackEntry.arguments?.getFloat("pinLng") ?: 0f).toDouble()
             val userLat = (backStackEntry.arguments?.getFloat("userLat") ?: 0f).toDouble()
             val userLng = (backStackEntry.arguments?.getFloat("userLng") ?: 0f).toDouble()
+            val address = Uri.decode(backStackEntry.arguments?.getString("address").orEmpty())
 
             // 일반 유저 생성 대상은 ISSUE / COMMUNICATION 두 가지. 그 외는 화면 진입을 차단한다.
             val category = when (pinType?.lowercase()) {
@@ -399,6 +405,7 @@ fun AppNavGraph(
                         pinLng = pinLng,
                         userLat = userLat,
                         userLng = userLng,
+                        address = address,
                         onBackClick = { navController.popBackStack() }
                     )
                 }

--- a/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
@@ -60,7 +60,8 @@ import com.issueissyu.fe.ui.screens.onboarding.TermsType as OnboardingTermsType
 @Composable
 fun AppNavGraph(
     navController: NavHostController,
-    paddingValues: PaddingValues
+    paddingValues: PaddingValues,
+    onMapLocationSelectionModeChanged: (Boolean) -> Unit = {},
 ) {
     val sessionViewModel: AppSessionViewModel = hiltViewModel()
     val context = LocalContext.current
@@ -223,6 +224,7 @@ fun AppNavGraph(
                     navController = navController,
                     focusPinId = backStackEntry.arguments?.getString("focusPinId"),
                     savedStateHandle = backStackEntry.savedStateHandle,
+                    onLocationSelectionModeChanged = onMapLocationSelectionModeChanged,
                 )
             }
         }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/community/detail/CommunityDetailViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/community/detail/CommunityDetailViewModel.kt
@@ -3,7 +3,9 @@ package com.issueissyu.fe.ui.screens.community.detail
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.issueissyu.fe.core.issue.IssueReliabilityPolling
 import com.issueissyu.fe.domain.model.community.CommunityItemKind
+import com.issueissyu.fe.domain.model.issue.IssueReliability
 import com.issueissyu.fe.domain.model.issue.IssueReliabilityStatus
 import com.issueissyu.fe.domain.model.pin.PinEmojiReaction
 import com.issueissyu.fe.domain.model.pin.PinEmojis
@@ -27,6 +29,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
@@ -48,6 +51,8 @@ class CommunityDetailViewModel @Inject constructor(
 ) : ViewModel() {
 
     private val communityId: Long = savedStateHandle.get<Long>("communityId") ?: 0L
+    private var issueReliabilityJob: Job? = null
+    private var observedReliabilityPinId: Long? = null
 
     private val _uiState = MutableStateFlow(CommunityDetailUiState())
     val uiState: StateFlow<CommunityDetailUiState> = _uiState.asStateFlow()
@@ -133,7 +138,7 @@ class CommunityDetailViewModel @Inject constructor(
                         _uiState.update { it.copy(emojiReactions = emptyList(), emojiPicker = CommunityEmojiPickerUiState()) }
                     }
                     if (detail.kind == CommunityItemKind.ISSUE && pinId != null) {
-                        loadIssueReliability(pinId)
+                        startIssueReliabilityObservation(pinId)
                     }
                 }
         }
@@ -464,19 +469,40 @@ class CommunityDetailViewModel @Inject constructor(
             }
     }
 
-    private suspend fun loadIssueReliability(pinId: Long) {
-        getIssueReliabilityUseCase(pinId)
-            .onSuccess { reliability ->
-                _uiState.update { state ->
-                    state.copy(
-                        detail = state.detail?.copy(
-                            reliabilityScore = reliability.score,
-                            reliabilityReason = reliability.reason,
+    private fun startIssueReliabilityObservation(pinId: Long) {
+        val isNewPin = observedReliabilityPinId != pinId
+        observedReliabilityPinId = pinId
+        issueReliabilityJob?.cancel()
+        issueReliabilityJob = viewModelScope.launch {
+            if (isNewPin) {
+                _uiState.update {
+                    it.copy(
+                        reliabilityStatus = IssueReliabilityStatus.PENDING,
+                        detail = it.detail?.copy(
+                            reliabilityScore = null,
+                            reliabilityReason = null,
                         ),
-                        reliabilityStatus = reliability.status,
                     )
                 }
             }
+            IssueReliabilityPolling.fetchWithPolling(
+                fetch = { getIssueReliabilityUseCase(pinId) },
+                onUpdate = { reliability -> applyIssueReliability(reliability) },
+            )
+        }
+    }
+
+    private fun applyIssueReliability(reliability: IssueReliability) {
+        if (observedReliabilityPinId != reliability.pinId) return
+        _uiState.update { state ->
+            state.copy(
+                detail = state.detail?.copy(
+                    reliabilityScore = reliability.score,
+                    reliabilityReason = reliability.reason,
+                ),
+                reliabilityStatus = reliability.status,
+            )
+        }
     }
 
     private fun PinEmojis.toEmojiReactions(): List<PinEmojiReaction> {

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/AutoScrollingNotice.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/AutoScrollingNotice.kt
@@ -66,23 +66,23 @@ fun AutoScrollingNotice(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(64.dp)
+            .height(48.dp)
             .clickable { onClick(currentNotice) },
         contentAlignment = Alignment.CenterStart
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(50.dp)
+                .height(36.dp)
                 .padding(start = 28.dp)
                 .shadow(
                     elevation = 6.dp,
-                    shape = RoundedCornerShape(25.dp),
+                    shape = RoundedCornerShape(18.dp),
                     clip = false
                 )
                 .background(
                     color = Color.White.copy(alpha = 0.7f),
-                    shape = RoundedCornerShape(25.dp)
+                    shape = RoundedCornerShape(18.dp)
                 )
                 .padding(start = 68.dp, end = 20.dp),
             verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/AutoScrollingNotice.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/AutoScrollingNotice.kt
@@ -66,7 +66,7 @@ fun AutoScrollingNotice(
     Box(
         modifier = modifier
             .fillMaxWidth()
-            .height(48.dp)
+            .height(42.dp)
             .clickable { onClick(currentNotice) },
         contentAlignment = Alignment.CenterStart
     ) {
@@ -74,9 +74,9 @@ fun AutoScrollingNotice(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(36.dp)
-                .padding(start = 28.dp)
+                .padding(start = 24.dp)
                 .shadow(
-                    elevation = 6.dp,
+                    elevation = 4.dp,
                     shape = RoundedCornerShape(18.dp),
                     clip = false
                 )
@@ -84,7 +84,7 @@ fun AutoScrollingNotice(
                     color = Color.White.copy(alpha = 0.7f),
                     shape = RoundedCornerShape(18.dp)
                 )
-                .padding(start = 68.dp, end = 20.dp),
+                .padding(start = 58.dp, end = 16.dp),
             verticalAlignment = Alignment.CenterVertically
         ) {
             AnimatedContent(
@@ -119,9 +119,9 @@ fun AutoScrollingNotice(
 
         Box(
             modifier = Modifier
-                .size(58.dp)
+                .size(46.dp)
                 .shadow(
-                    elevation = 8.dp,
+                    elevation = 5.dp,
                     shape = CircleShape,
                     clip = false
                 )
@@ -135,7 +135,7 @@ fun AutoScrollingNotice(
                 painter = painterResource(id = iconResId),
                 contentDescription = "공지",
                 tint = Color.Unspecified,
-                modifier = Modifier.size(42.dp)
+                modifier = Modifier.size(32.dp)
             )
         }
     }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -5,6 +5,7 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.clickable
@@ -230,7 +231,8 @@ fun MapScreen(
                     "&pinLat=${event.pinCoordinate.latitude}" +
                     "&pinLng=${event.pinCoordinate.longitude}" +
                     "&userLat=${event.userCoordinate.latitude}" +
-                    "&userLng=${event.userCoordinate.longitude}"
+                    "&userLng=${event.userCoordinate.longitude}" +
+                    "&address=${Uri.encode(event.address)}"
             )
         }
     }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -481,7 +481,7 @@ fun MapScreen(
                 painter = painterResource(id = R.drawable.patchnotebutton),
                 contentDescription = "패치노트",
                 modifier = Modifier
-                    .size(60.dp)
+                    .size(70.dp)
                     .clickable {
                         navController.navigate(AppDestinations.PATCH_NOTE_ROUTE)
                     },
@@ -494,7 +494,7 @@ fun MapScreen(
                 painter = painterResource(id = R.drawable.findspot),
                 contentDescription = "내 위치 찾기",
                 modifier = Modifier
-                    .size(52.dp)
+                    .size(60.dp)
                     .clickable {
                         moveToCurrentLocation()
                     },

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -51,6 +51,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import kotlinx.coroutines.flow.collectLatest
@@ -82,6 +83,8 @@ import com.issueissyu.fe.ui.theme.White
 
 // 위치 권한 요청 코드 상수
 private const val LOCATION_PERMISSION_REQUEST_CODE = 1000
+const val PIN_CREATE_MAP_REFRESH_KEY = "pin_create_map_refresh"
+const val PIN_CREATE_FOCUS_PIN_ID_KEY = "pin_create_focus_pin_id"
 
 // Context에서 Activity를 찾는 헬퍼 함수
 private fun Context.findActivity(): Activity? {
@@ -103,6 +106,7 @@ private fun Context.findActivity(): Activity? {
 fun MapScreen(
     navController: NavHostController,
     focusPinId: String? = null,
+    savedStateHandle: SavedStateHandle,
     viewModel: MapViewModel = hiltViewModel()
 ) {
     val showResearchButton by viewModel.showResearchButton.collectAsStateWithLifecycle()
@@ -240,6 +244,19 @@ fun MapScreen(
     LaunchedEffect(Unit) {
         viewModel.messageEvents.collectLatest { message ->
             snackbarHostState.showSnackbar(message)
+        }
+    }
+
+    LaunchedEffect(savedStateHandle) {
+        savedStateHandle.getStateFlow(PIN_CREATE_MAP_REFRESH_KEY, false).collectLatest { shouldRefresh ->
+            if (!shouldRefresh) return@collectLatest
+            viewModel.fetchPinsInBounds()
+            val createdPinId = savedStateHandle.get<String>(PIN_CREATE_FOCUS_PIN_ID_KEY).orEmpty()
+            if (createdPinId.isNotBlank()) {
+                viewModel.selectPinById(createdPinId)
+            }
+            savedStateHandle[PIN_CREATE_MAP_REFRESH_KEY] = false
+            savedStateHandle[PIN_CREATE_FOCUS_PIN_ID_KEY] = ""
         }
     }
 

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -37,6 +37,7 @@ import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateListOf
@@ -107,6 +108,7 @@ fun MapScreen(
     navController: NavHostController,
     focusPinId: String? = null,
     savedStateHandle: SavedStateHandle,
+    onLocationSelectionModeChanged: (Boolean) -> Unit = {},
     viewModel: MapViewModel = hiltViewModel()
 ) {
     val showResearchButton by viewModel.showResearchButton.collectAsStateWithLifecycle()
@@ -119,12 +121,22 @@ fun MapScreen(
     val selectedPinCategory by viewModel.selectedPinCategory.collectAsStateWithLifecycle()
     val currentUserId = viewModel.currentUserId
 
+    LaunchedEffect(isLocationSelectionMode) {
+        onLocationSelectionModeChanged(isLocationSelectionMode)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            onLocationSelectionModeChanged(false)
+        }
+    }
+
     // TODO: ViewModel에서 combine(_mapPins, _selectedCategory)로 visibleMapPins StateFlow를 노출하고, UI는 collect만 하도록 정리
 
-    val visibleMapPins = if (selectedCategory == null) {
-        mapPins
-    } else {
-        mapPins.filter { it.category == selectedCategory }
+    val visibleMapPins = when {
+        isLocationSelectionMode -> emptyList()
+        selectedCategory == null -> mapPins
+        else -> mapPins.filter { it.category == selectedCategory }
     }
 
     var naverMapInstance by remember { mutableStateOf<NaverMap?>(null) }
@@ -368,53 +380,53 @@ fun MapScreen(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.TopCenter)
-                .statusBarsPadding()
-                .padding(top = 16.dp)
-        ) {
-            val errorContainer = MaterialTheme.colorScheme.errorContainer
-            val secondaryContainer = MaterialTheme.colorScheme.secondaryContainer
-            val primaryContainer = MaterialTheme.colorScheme.primaryContainer
-            val tertiaryContainer = MaterialTheme.colorScheme.tertiaryContainer
-
-            val sampleCategories = remember(
-                errorContainer,
-                secondaryContainer,
-                primaryContainer,
-                tertiaryContainer
+        if (!isLocationSelectionMode) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.TopCenter)
+                    .statusBarsPadding()
+                    .padding(top = 16.dp)
             ) {
-                listOf(
-                    CategoryItem("이슈", R.drawable.issue, Issue, errorContainer),
-                    CategoryItem("소통", R.drawable.communicate, Communication, secondaryContainer),
-                    CategoryItem("가게", R.drawable.shop, Shop, primaryContainer),
-                    CategoryItem("축제", R.drawable.festival, Festival, tertiaryContainer)
+                val errorContainer = MaterialTheme.colorScheme.errorContainer
+                val secondaryContainer = MaterialTheme.colorScheme.secondaryContainer
+                val primaryContainer = MaterialTheme.colorScheme.primaryContainer
+                val tertiaryContainer = MaterialTheme.colorScheme.tertiaryContainer
+
+                val sampleCategories = remember(
+                    errorContainer,
+                    secondaryContainer,
+                    primaryContainer,
+                    tertiaryContainer
+                ) {
+                    listOf(
+                        CategoryItem("이슈", R.drawable.issue, Issue, errorContainer),
+                        CategoryItem("소통", R.drawable.communicate, Communication, secondaryContainer),
+                        CategoryItem("가게", R.drawable.shop, Shop, primaryContainer),
+                        CategoryItem("축제", R.drawable.festival, Festival, tertiaryContainer)
+                    )
+                }
+
+                val selectedCategoryLabel = when (selectedCategory) {
+                    PinCategory.ISSUE -> "이슈"
+                    PinCategory.COMMUNICATION -> "소통"
+                    PinCategory.SHOP -> "가게"
+                    PinCategory.FESTIVAL -> "축제"
+                    null -> null
+                }
+
+                CategoryButtons(
+                    categories = sampleCategories,
+                    selectedCategory = selectedCategoryLabel,
+                    onCategorySelected = { category ->
+                        viewModel.onCategorySelected(category)
+                    },
+                    onNotificationClick = {
+                        // TODO: 알림 목록 UI 또는 알림 화면 연결
+                    },
+                    modifier = Modifier.fillMaxWidth()
                 )
-            }
 
-            val selectedCategoryLabel = when (selectedCategory) {
-                PinCategory.ISSUE -> "이슈"
-                PinCategory.COMMUNICATION -> "소통"
-                PinCategory.SHOP -> "가게"
-                PinCategory.FESTIVAL -> "축제"
-                null -> null
-            }
-
-            CategoryButtons(
-                categories = sampleCategories,
-                selectedCategory = selectedCategoryLabel,
-                onCategorySelected = { category ->
-                    viewModel.onCategorySelected(category)
-                },
-                onNotificationClick = {
-                    // TODO: 알림 목록 UI 또는 알림 화면 연결
-                },
-                modifier = Modifier.fillMaxWidth()
-            )
-
-            if (!isLocationSelectionMode) {
                 AutoScrollingNotice(
                     notices = notices.map { notice ->
                         NoticeUiModel(
@@ -439,7 +451,7 @@ fun MapScreen(
             }
         }
 
-        if (showResearchButton) {
+        if (showResearchButton && !isLocationSelectionMode) {
             Button(
                 onClick = {
                     viewModel.fetchPinsInBounds()
@@ -471,53 +483,55 @@ fun MapScreen(
             }
         }
 
-        Column(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(end = 16.dp, bottom = 16.dp),
-            horizontalAlignment = Alignment.CenterHorizontally
-        ) {
-            Icon(
-                painter = painterResource(id = R.drawable.patchnotebutton),
-                contentDescription = "패치노트",
+        if (!isLocationSelectionMode) {
+            Column(
                 modifier = Modifier
-                    .size(70.dp)
-                    .clickable {
-                        navController.navigate(AppDestinations.PATCH_NOTE_ROUTE)
-                    },
-                tint = Color.Unspecified
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            Icon(
-                painter = painterResource(id = R.drawable.findspot),
-                contentDescription = "내 위치 찾기",
-                modifier = Modifier
-                    .size(60.dp)
-                    .clickable {
-                        moveToCurrentLocation()
-                    },
-                tint = Color.Unspecified
-            )
-
-            Spacer(modifier = Modifier.height(8.dp))
-
-            FloatingActionButton(
-                onClick = { viewModel.openPinTypeSelector() },
-                modifier = Modifier.size(56.dp),
-                shape = CircleShape,
-                containerColor = BrandColor
+                    .align(Alignment.BottomEnd)
+                    .padding(end = 16.dp, bottom = 16.dp),
+                horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 Icon(
-                    imageVector = Icons.Default.AddLocation,
-                    contentDescription = "핀 생성",
-                    tint = White
+                    painter = painterResource(id = R.drawable.patchnotebutton),
+                    contentDescription = "패치노트",
+                    modifier = Modifier
+                        .size(70.dp)
+                        .clickable {
+                            navController.navigate(AppDestinations.PATCH_NOTE_ROUTE)
+                        },
+                    tint = Color.Unspecified
                 )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                Icon(
+                    painter = painterResource(id = R.drawable.findspot),
+                    contentDescription = "내 위치 찾기",
+                    modifier = Modifier
+                        .size(60.dp)
+                        .clickable {
+                            moveToCurrentLocation()
+                        },
+                    tint = Color.Unspecified
+                )
+
+                Spacer(modifier = Modifier.height(8.dp))
+
+                FloatingActionButton(
+                    onClick = { viewModel.openPinTypeSelector() },
+                    modifier = Modifier.size(56.dp),
+                    shape = CircleShape,
+                    containerColor = BrandColor
+                ) {
+                    Icon(
+                        imageVector = Icons.Default.AddLocation,
+                        contentDescription = "핀 생성",
+                        tint = White
+                    )
+                }
             }
         }
 
-        if (selectedPin != null) {
+        if (selectedPin != null && !isLocationSelectionMode) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
@@ -525,7 +539,7 @@ fun MapScreen(
             )
         }
 
-        selectedPin?.let { pin ->
+        selectedPin?.takeUnless { isLocationSelectionMode }?.let { pin ->
             PinSummaryCard(
                 pin = pin,
                 currentUserId = currentUserId,

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -481,7 +481,7 @@ fun MapScreen(
                 painter = painterResource(id = R.drawable.patchnotebutton),
                 contentDescription = "패치노트",
                 modifier = Modifier
-                    .size(56.dp)
+                    .size(60.dp)
                     .clickable {
                         navController.navigate(AppDestinations.PATCH_NOTE_ROUTE)
                     },
@@ -494,7 +494,7 @@ fun MapScreen(
                 painter = painterResource(id = R.drawable.findspot),
                 contentDescription = "내 위치 찾기",
                 modifier = Modifier
-                    .size(48.dp)
+                    .size(52.dp)
                     .clickable {
                         moveToCurrentLocation()
                     },

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -414,27 +414,29 @@ fun MapScreen(
                 modifier = Modifier.fillMaxWidth()
             )
 
-            AutoScrollingNotice(
-                notices = notices.map { notice ->
-                    NoticeUiModel(
-                        id = notice.id,
-                        title = notice.content,
-                        pinId = notice.pinId
-                    )
-                },
-                iconResId = R.drawable.ic_megaphone,
-                onClick = { clickedNotice ->
-                    val communityId = clickedNotice.pinId?.toLongOrNull()
-                    if (communityId != null) {
-                        navController.navigate(
-                            AppDestinations.communityDetailRoute(communityId)
+            if (!isLocationSelectionMode) {
+                AutoScrollingNotice(
+                    notices = notices.map { notice ->
+                        NoticeUiModel(
+                            id = notice.id,
+                            title = notice.content,
+                            pinId = notice.pinId
                         )
-                    }
-                },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = 16.dp, vertical = 8.dp)
-            )
+                    },
+                    iconResId = R.drawable.ic_megaphone,
+                    onClick = { clickedNotice ->
+                        val communityId = clickedNotice.pinId?.toLongOrNull()
+                        if (communityId != null) {
+                            navController.navigate(
+                                AppDestinations.communityDetailRoute(communityId)
+                            )
+                        }
+                    },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 16.dp, vertical = 8.dp)
+                )
+            }
         }
 
         if (showResearchButton) {

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
@@ -27,7 +27,8 @@ import javax.inject.Inject
 data class PinCreationNavigationEvent(
     val category: PinCategory,
     val pinCoordinate: PinCoordinate,
-    val userCoordinate: PinCoordinate
+    val userCoordinate: PinCoordinate,
+    val address: String,
 )
 
 @HiltViewModel
@@ -253,12 +254,13 @@ class MapViewModel @Inject constructor(
             locationRepository.checkPinCreationAvailable(
                 userCoordinate = currentCoordinate,
                 pinCoordinate = selectedCoordinate,
-            ).onSuccess {
+            ).onSuccess { address ->
                 _navigateToPinCreation.emit(
                     PinCreationNavigationEvent(
                         category = selectedCategory,
                         pinCoordinate = selectedCoordinate,
-                        userCoordinate = currentCoordinate
+                        userCoordinate = currentCoordinate,
+                        address = address,
                     )
                 )
                 exitLocationSelectionMode()

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
@@ -233,6 +233,7 @@ class MapViewModel @Inject constructor(
         _isLocationSelectionMode.value = true
         _selectedPinCategory.value = category
         _selectedPinCoordinate.value = null
+        _selectedPin.value = null
     }
 
     fun exitLocationSelectionMode() {

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
@@ -266,6 +266,8 @@ class MapViewModel @Inject constructor(
                 exitLocationSelectionMode()
             }.onFailure { e ->
                 _messageEvents.emit(e.message?.takeIf { it.isNotBlank() } ?: "이 위치에는 핀을 생성할 수 없습니다.")
+                // 생성 불가 위치를 선택한 경우 위치 선택 모드를 종료해 핀 종류 선택부터 다시 진행하도록 한다.
+                exitLocationSelectionMode()
             }
         }
     }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapViewModel.kt
@@ -11,6 +11,7 @@ import com.issueissyu.fe.domain.model.MapPinMarker
 import com.issueissyu.fe.domain.model.pin.PinCoordinate
 import com.issueissyu.fe.domain.model.pin.PinEmojiReaction
 import com.issueissyu.fe.domain.model.pin.PinEmojis
+import com.issueissyu.fe.domain.repository.LocationRepository
 import com.issueissyu.fe.domain.repository.MapRepository
 import com.issueissyu.fe.domain.repository.PinRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -33,6 +34,7 @@ data class PinCreationNavigationEvent(
 class MapViewModel @Inject constructor(
     private val mapRepository: MapRepository,
     private val pinRepository: PinRepository,
+    private val locationRepository: LocationRepository,
     private val tokenManager: TokenManager,
 ) : ViewModel() {
 
@@ -240,21 +242,29 @@ class MapViewModel @Inject constructor(
     }
 
     fun onMapCoordinateSelected(selectedCoordinate: PinCoordinate, currentCoordinate: PinCoordinate?) {
-        if (!_isLocationSelectionMode.value || _selectedPinCategory.value == null) return
+        val selectedCategory = _selectedPinCategory.value
+        if (!_isLocationSelectionMode.value || selectedCategory == null) return
         if (currentCoordinate == null) {
-            // TODO: 현재 위치를 가져오지 못한 경우 안내 UI 표시
+            _messageEvents.tryEmit("현재 위치를 확인한 뒤 다시 시도해주세요.")
             return
         }
 
         viewModelScope.launch {
-            _navigateToPinCreation.emit(
-                PinCreationNavigationEvent(
-                    category = _selectedPinCategory.value!!,
-                    pinCoordinate = selectedCoordinate,
-                    userCoordinate = currentCoordinate
+            locationRepository.checkPinCreationAvailable(
+                userCoordinate = currentCoordinate,
+                pinCoordinate = selectedCoordinate,
+            ).onSuccess {
+                _navigateToPinCreation.emit(
+                    PinCreationNavigationEvent(
+                        category = selectedCategory,
+                        pinCoordinate = selectedCoordinate,
+                        userCoordinate = currentCoordinate
+                    )
                 )
-            )
-            exitLocationSelectionMode()
+                exitLocationSelectionMode()
+            }.onFailure { e ->
+                _messageEvents.emit(e.message?.takeIf { it.isNotBlank() } ?: "이 위치에는 핀을 생성할 수 없습니다.")
+            }
         }
     }
 

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -1,5 +1,8 @@
 package com.issueissyu.fe.ui.screens.pincreate
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.PickVisualMediaRequest
 import androidx.activity.result.contract.ActivityResultContracts
@@ -25,25 +28,36 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PhotoCamera
+import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Place
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.issueissyu.fe.core.constants.PinImageUploadConstraints
+import com.issueissyu.fe.core.media.CapturedImageSaver
 import com.issueissyu.fe.domain.model.pin.PinCategory
 import com.issueissyu.fe.ui.components.CommonButton
 import com.issueissyu.fe.ui.components.CommonTextField
@@ -62,6 +76,7 @@ import com.issueissyu.fe.ui.theme.White
 import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImage
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PinCreateScreen(
     category: PinCategory,
@@ -76,12 +91,101 @@ fun PinCreateScreen(
     viewModel: PinCreateViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickMultipleVisualMedia(
-            maxItems = PinImageUploadConstraints.MAX_COUNT,
-        ),
-    ) { uris ->
-        viewModel.addImageUris(uris.map { it.toString() })
+    val context = LocalContext.current
+    var showPhotoSourceSheet by remember { mutableStateOf(false) }
+
+    val remainingSlots = PinImageUploadConstraints.MAX_COUNT - uiState.imageUris.size
+    val albumPickRequest = PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+
+    var launchAlbumPicker by remember { mutableStateOf<(() -> Unit)?>(null) }
+
+    if (remainingSlots > 1) {
+        key(remainingSlots) {
+            val imagePickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = remainingSlots),
+            ) { uris ->
+                viewModel.addImageUris(uris.map { it.toString() })
+            }
+            SideEffect {
+                launchAlbumPicker = {
+                    imagePickerLauncher.launch(albumPickRequest)
+                }
+            }
+        }
+    } else if (remainingSlots == 1) {
+        key("single-album") {
+            val imagePickerLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.PickVisualMedia(),
+            ) { uri ->
+                uri?.let { picked -> viewModel.addImageUris(listOf(picked.toString())) }
+            }
+            SideEffect {
+                launchAlbumPicker = {
+                    imagePickerLauncher.launch(albumPickRequest)
+                }
+            }
+        }
+    } else {
+        SideEffect {
+            launchAlbumPicker = null
+        }
+    }
+
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicturePreview(),
+    ) { bitmap ->
+        when {
+            bitmap == null -> Unit
+            else -> {
+                val uri = CapturedImageSaver.saveJpegToCache(context, bitmap, "pin-create")
+                if (uri == null) {
+                    Toast.makeText(context, "사진을 저장하지 못했습니다.", Toast.LENGTH_SHORT).show()
+                } else {
+                    viewModel.addImageUris(listOf(uri))
+                }
+            }
+        }
+    }
+
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { granted ->
+        if (granted) {
+            cameraLauncher.launch(null)
+        } else {
+            Toast.makeText(context, "카메라 권한이 필요합니다.", Toast.LENGTH_SHORT).show()
+        }
+    }
+
+    val launchCamera = remember(cameraLauncher, cameraPermissionLauncher, context) {
+        {
+            showPhotoSourceSheet = false
+            val hasPermission = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA,
+            ) == PackageManager.PERMISSION_GRANTED
+            if (hasPermission) {
+                cameraLauncher.launch(null)
+            } else {
+                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            }
+        }
+    }
+
+    val launchAlbum: () -> Unit = remember {
+        {
+            showPhotoSourceSheet = false
+            launchAlbumPicker?.invoke()
+            Unit
+        }
+    }
+
+    if (showPhotoSourceSheet) {
+        PhotoAddSourceBottomSheet(
+            onDismissRequest = { showPhotoSourceSheet = false },
+            onAlbumClick = launchAlbum,
+            onCameraClick = launchCamera,
+        )
     }
 
     LaunchedEffect(category, pinLat, pinLng, userLat, userLng, address) {
@@ -101,11 +205,7 @@ fun PinCreateScreen(
         onTitleChange = viewModel::onTitleChange,
         onDescriptionChange = viewModel::onDescriptionChange,
         onToneChange = viewModel::onToneChange,
-        onPhotoAddClick = {
-            imagePickerLauncher.launch(
-                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
-            )
-        },
+        onPhotoAddClick = { showPhotoSourceSheet = true },
         onPhotoRemoveClick = viewModel::removeImageUri,
         onSetMainImageClick = viewModel::setMainImageUri,
         onAiDraftClick = viewModel::createAiDraft,
@@ -284,6 +384,72 @@ private fun PhotoUploadSection(
                 )
             }
         }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun PhotoAddSourceBottomSheet(
+    onDismissRequest: () -> Unit,
+    onAlbumClick: () -> Unit,
+    onCameraClick: () -> Unit,
+) {
+    ModalBottomSheet(
+        onDismissRequest = onDismissRequest,
+        containerColor = White,
+        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
+        dragHandle = null,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+        ) {
+            Text(
+                text = "사진 추가",
+                style = IssueTypo.Bold18.copy(color = Title),
+            )
+            PhotoSourceOptionRow(
+                icon = Icons.Default.PhotoLibrary,
+                label = "앨범에서 선택",
+                onClick = onAlbumClick,
+            )
+            PhotoSourceOptionRow(
+                icon = Icons.Default.PhotoCamera,
+                label = "카메라로 촬영",
+                onClick = onCameraClick,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+        }
+    }
+}
+
+@Composable
+private fun PhotoSourceOptionRow(
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 12.dp, vertical = 14.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(12.dp),
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Gray_5,
+            modifier = Modifier.size(24.dp),
+        )
+        Text(
+            text = label,
+            style = IssueTypo.Regular15.copy(color = TextColor),
+        )
     }
 }
 

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -277,7 +277,12 @@ private fun PinCreateContent(
                 value = uiState.description,
                 onValueChange = onDescriptionChange,
                 label = "상세 설명",
-                placeholder = "상세 설명을 작성해 주세요.\n해시태그를 눌러 이슈있슈 AI로 빠르게 원하는 말투로 글을 작성할 수 있어요!",
+                placeholder = when (category) {
+                    PinCategory.ISSUE ->
+                        "상세 설명을 작성해 주세요.\n해시태그를 눌러 이슈있슈 AI로 빠르게 원하는 말투로 글을 작성할 수 있어요!"
+                    PinCategory.COMMUNICATION -> "상세 설명을 작성해 주세요."
+                    PinCategory.SHOP, PinCategory.FESTIVAL -> "상세 설명을 작성해 주세요."
+                },
                 maxLines = 8,
                 maxLength = 500,
                 textStyle = IssueTypo.Regular16

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.issueissyu.fe.core.constants.PinImageUploadConstraints
 import com.issueissyu.fe.domain.model.pin.PinCategory
 import com.issueissyu.fe.ui.components.CommonButton
 import com.issueissyu.fe.ui.components.CommonTextField
@@ -75,7 +76,9 @@ fun PinCreateScreen(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val imagePickerLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = MAX_IMAGE_COUNT),
+        contract = ActivityResultContracts.PickMultipleVisualMedia(
+            maxItems = PinImageUploadConstraints.MAX_COUNT,
+        ),
     ) { uris ->
         viewModel.addImageUris(uris.map { it.toString() })
     }
@@ -103,6 +106,7 @@ fun PinCreateScreen(
             )
         },
         onPhotoRemoveClick = viewModel::removeImageUri,
+        onSetMainImageClick = viewModel::setMainImageUri,
         onAiDraftClick = viewModel::createAiDraft,
         onSubmit = viewModel::submitPin,
         modifier = modifier
@@ -119,6 +123,7 @@ private fun PinCreateContent(
     onToneChange: (String) -> Unit,
     onPhotoAddClick: () -> Unit,
     onPhotoRemoveClick: (String) -> Unit,
+    onSetMainImageClick: (String) -> Unit,
     onAiDraftClick: () -> Unit,
     onSubmit: () -> Unit,
     modifier: Modifier = Modifier
@@ -148,8 +153,10 @@ private fun PinCreateContent(
         ) {
             PhotoUploadSection(
                 imageUris = uiState.imageUris,
+                mainImageUri = uiState.mainImageUri,
                 onPhotoAddClick = onPhotoAddClick,
                 onPhotoRemoveClick = onPhotoRemoveClick,
+                onSetMainImageClick = onSetMainImageClick,
             )
 
             LocationSection(
@@ -240,15 +247,17 @@ private fun SectionLabel(
 @Composable
 private fun PhotoUploadSection(
     imageUris: List<String>,
+    mainImageUri: String?,
     onPhotoAddClick: () -> Unit,
     onPhotoRemoveClick: (String) -> Unit,
+    onSetMainImageClick: (String) -> Unit,
 ) {
     Column {
         SectionLabel(
             text = "사진",
             trailing = {
                 Text(
-                    text = "${imageUris.size}/$MAX_IMAGE_COUNT",
+                    text = "${imageUris.size}/${PinImageUploadConstraints.MAX_COUNT}",
                     style = IssueTypo.Regular12.copy(color = Gray_6)
                 )
             }
@@ -258,12 +267,14 @@ private fun PhotoUploadSection(
             horizontalArrangement = Arrangement.spacedBy(10.dp),
             verticalArrangement = Arrangement.spacedBy(10.dp),
         ) {
-            if (imageUris.size < MAX_IMAGE_COUNT) {
+            if (imageUris.size < PinImageUploadConstraints.MAX_COUNT) {
                 PhotoAddBox(onClick = onPhotoAddClick)
             }
             imageUris.forEach { uri ->
                 SelectedPhotoBox(
                     uri = uri,
+                    isMain = uri == mainImageUri,
+                    onSetMainClick = { onSetMainImageClick(uri) },
                     onRemoveClick = { onPhotoRemoveClick(uri) },
                 )
             }
@@ -300,6 +311,8 @@ private fun PhotoAddBox(onClick: () -> Unit) {
 @Composable
 private fun SelectedPhotoBox(
     uri: String,
+    isMain: Boolean,
+    onSetMainClick: () -> Unit,
     onRemoveClick: () -> Unit,
 ) {
     Box(
@@ -307,6 +320,14 @@ private fun SelectedPhotoBox(
             .size(80.dp)
             .clip(RoundedCornerShape(12.dp))
             .background(Gray_1)
+            .then(
+                if (isMain) {
+                    Modifier.border(2.dp, Orange, RoundedCornerShape(12.dp))
+                } else {
+                    Modifier
+                },
+            )
+            .clickable(onClick = onSetMainClick),
     ) {
         AsyncImage(
             model = uri,
@@ -314,6 +335,20 @@ private fun SelectedPhotoBox(
             contentScale = ContentScale.Crop,
             modifier = Modifier.fillMaxSize(),
         )
+        if (isMain) {
+            Box(
+                modifier = Modifier
+                    .align(Alignment.BottomStart)
+                    .padding(4.dp)
+                    .background(Orange, RoundedCornerShape(6.dp))
+                    .padding(horizontal = 6.dp, vertical = 2.dp),
+            ) {
+                Text(
+                    text = "대표",
+                    style = IssueTypo.Regular12.copy(color = White),
+                )
+            }
+        }
         IconButton(
             onClick = onRemoveClick,
             modifier = Modifier
@@ -477,6 +512,7 @@ private fun PinCreateScreenPreview_IssueFilled() {
             onToneChange = {},
             onPhotoAddClick = {},
             onPhotoRemoveClick = {},
+            onSetMainImageClick = {},
             onAiDraftClick = {},
             onSubmit = {}
         )
@@ -503,10 +539,9 @@ private fun PinCreateScreenPreview_Communication() {
             onToneChange = {},
             onPhotoAddClick = {},
             onPhotoRemoveClick = {},
+            onSetMainImageClick = {},
             onAiDraftClick = {},
             onSubmit = {}
         )
     }
 }
-
-private const val MAX_IMAGE_COUNT = 5

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -183,10 +183,14 @@ private fun PinCreateContent(
                 textStyle = IssueTypo.Regular16
             )
 
-            ToneSelectionSection(
-                selectedTone = uiState.selectedTone,
-                onToneChange = onToneChange
-            )
+            if (category == PinCategory.ISSUE) {
+                ToneSelectionSection(
+                    toneOptions = uiState.toneOptions,
+                    isLoading = uiState.isLoadingToneOptions,
+                    selectedTone = uiState.selectedTone,
+                    onToneChange = onToneChange,
+                )
+            }
 
             if (category == PinCategory.ISSUE) {
                 AiDraftButton(
@@ -418,30 +422,29 @@ private fun LocationSection(
     }
 }
 
-// TODO: 서버/기획 확정 후 enum 또는 서버 응답 기반으로 교체
-private val PinToneOptions = listOf(
-    "없음",
-    "한줄요약형",
-    "상황설명형",
-    "개선요청형",
-    "긴급요청형",
-    "불편호소형"
-)
-
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ToneSelectionSection(
+    toneOptions: List<String>,
+    isLoading: Boolean,
     selectedTone: String?,
-    onToneChange: (String) -> Unit
+    onToneChange: (String) -> Unit,
 ) {
     Column {
         SectionLabel(text = "말투 설정")
+        if (isLoading && toneOptions.isEmpty()) {
+            Text(
+                text = "말투 목록 불러오는 중…",
+                style = IssueTypo.Regular12.copy(color = Gray_4),
+            )
+            return@Column
+        }
         FlowRow(
             modifier = Modifier.fillMaxWidth(),
             horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            PinToneOptions.forEach { tone ->
+            toneOptions.forEach { tone ->
                 ToneChip(
                     label = tone,
                     selected = selectedTone == tone,
@@ -505,7 +508,8 @@ private fun PinCreateScreenPreview_IssueFilled() {
                 description = "퇴근 시간대 사람이 너무 많은데 신호가 30초밖에 안 돼서 못 건너요.",
                 address = "서울 광진구 능동로 120",
                 locationName = "건국대학교 입구",
-                selectedTone = "개선요청형"
+                toneOptions = listOf("없음", "한줄요약형", "상황설명형", "개선요청형", "긴급요청형", "불편호소형"),
+                selectedTone = "개선요청형",
             ),
             onBackClick = {},
             onTitleChange = {},
@@ -532,7 +536,6 @@ private fun PinCreateScreenPreview_Communication() {
                 description = "어린이대공원 근처 살아요. 가볍게 한 바퀴 도실 분 모집합니다.",
                 address = "서울 광진구 화양동",
                 locationName = "화양동 주민센터 앞",
-                selectedTone = "상황설명형"
             ),
             onBackClick = {},
             onTitleChange = {},

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.issueissyu.fe.domain.model.pin.PinCategory
@@ -78,6 +79,7 @@ fun PinCreateScreen(
         onTitleChange = viewModel::onTitleChange,
         onDescriptionChange = viewModel::onDescriptionChange,
         onToneChange = viewModel::onToneChange,
+        onAiDraftClick = viewModel::createAiDraft,
         onSubmit = viewModel::submitPin,
         modifier = modifier
     )
@@ -91,6 +93,7 @@ private fun PinCreateContent(
     onTitleChange: (String) -> Unit,
     onDescriptionChange: (String) -> Unit,
     onToneChange: (String) -> Unit,
+    onAiDraftClick: () -> Unit,
     onSubmit: () -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -146,6 +149,24 @@ private fun PinCreateContent(
                 selectedTone = uiState.selectedTone,
                 onToneChange = onToneChange
             )
+
+            if (category == PinCategory.ISSUE) {
+                AiDraftButton(
+                    isLoading = uiState.isGeneratingAiContent,
+                    isEnabled = uiState.title.isNotBlank() &&
+                        uiState.description.isNotBlank() &&
+                        !uiState.isGeneratingAiContent,
+                    onClick = onAiDraftClick,
+                )
+            }
+
+            uiState.errorMessage?.takeIf { it.isNotBlank() }?.let { message ->
+                Text(
+                    text = message,
+                    style = IssueTypo.Regular12.copy(color = Orange),
+                    modifier = Modifier.padding(horizontal = 10.dp)
+                )
+            }
 
             Spacer(modifier = Modifier.height(4.dp))
         }
@@ -288,15 +309,14 @@ private fun LocationSection(
 
 // TODO: 서버/기획 확정 후 enum 또는 서버 응답 기반으로 교체
 private val PinToneOptions = listOf(
-    "#가볍게",
-    "#공손하게",
-    "#친근하게",
-    "#부드럽게",
-    "#진중하게",
-    "#공식적으로"
+    "없음",
+    "한줄요약형",
+    "상황설명형",
+    "개선요청형",
+    "긴급요청형",
+    "불편호소형"
 )
 
-// TODO: 선택된 말투를 AI 초안 요청 파라미터에 포함
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun ToneSelectionSection(
@@ -319,6 +339,21 @@ private fun ToneSelectionSection(
             }
         }
     }
+}
+
+@Composable
+private fun AiDraftButton(
+    isLoading: Boolean,
+    isEnabled: Boolean,
+    onClick: () -> Unit,
+) {
+    CommonButton(
+        onClick = onClick,
+        text = if (isLoading) "AI 글 작성 중" else "AI 글쓰기",
+        isEnabled = isEnabled,
+        textStyle = IssueTypo.Bold18.copy(fontSize = 16.sp),
+        modifier = Modifier.fillMaxWidth()
+    )
 }
 
 @Composable
@@ -365,6 +400,7 @@ private fun PinCreateScreenPreview_IssueFilled() {
             onTitleChange = {},
             onDescriptionChange = {},
             onToneChange = {},
+            onAiDraftClick = {},
             onSubmit = {}
         )
     }
@@ -388,6 +424,7 @@ private fun PinCreateScreenPreview_Communication() {
             onTitleChange = {},
             onDescriptionChange = {},
             onToneChange = {},
+            onAiDraftClick = {},
             onSubmit = {}
         )
     }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -1,5 +1,8 @@
 package com.issueissyu.fe.ui.screens.pincreate
 
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -20,10 +23,12 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PhotoCamera
 import androidx.compose.material.icons.filled.Place
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,6 +37,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
@@ -53,8 +59,8 @@ import com.issueissyu.fe.ui.theme.Text as TextColor
 import com.issueissyu.fe.ui.theme.Title
 import com.issueissyu.fe.ui.theme.White
 import androidx.compose.ui.tooling.preview.Preview
+import coil.compose.AsyncImage
 
-// TODO: AI 초안 응답을 title/description 상태에 반영
 @Composable
 fun PinCreateScreen(
     category: PinCategory,
@@ -67,6 +73,11 @@ fun PinCreateScreen(
     viewModel: PinCreateViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val imagePickerLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = MAX_IMAGE_COUNT),
+    ) { uris ->
+        viewModel.addImageUris(uris.map { it.toString() })
+    }
 
     LaunchedEffect(category, pinLat, pinLng, userLat, userLng) {
         viewModel.initialize(category, pinLat, pinLng, userLat, userLng)
@@ -85,6 +96,12 @@ fun PinCreateScreen(
         onTitleChange = viewModel::onTitleChange,
         onDescriptionChange = viewModel::onDescriptionChange,
         onToneChange = viewModel::onToneChange,
+        onPhotoAddClick = {
+            imagePickerLauncher.launch(
+                PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly),
+            )
+        },
+        onPhotoRemoveClick = viewModel::removeImageUri,
         onAiDraftClick = viewModel::createAiDraft,
         onSubmit = viewModel::submitPin,
         modifier = modifier
@@ -99,6 +116,8 @@ private fun PinCreateContent(
     onTitleChange: (String) -> Unit,
     onDescriptionChange: (String) -> Unit,
     onToneChange: (String) -> Unit,
+    onPhotoAddClick: () -> Unit,
+    onPhotoRemoveClick: (String) -> Unit,
     onAiDraftClick: () -> Unit,
     onSubmit: () -> Unit,
     modifier: Modifier = Modifier
@@ -126,7 +145,11 @@ private fun PinCreateContent(
                 .padding(horizontal = 28.dp, vertical = 8.dp),
             verticalArrangement = Arrangement.spacedBy(24.dp)
         ) {
-            PhotoUploadSection(imageCount = uiState.imageUris.size)
+            PhotoUploadSection(
+                imageUris = uiState.imageUris,
+                onPhotoAddClick = onPhotoAddClick,
+                onPhotoRemoveClick = onPhotoRemoveClick,
+            )
 
             LocationSection(
                 address = uiState.address,
@@ -212,25 +235,37 @@ private fun SectionLabel(
     }
 }
 
-// TODO: 이미지 선택/업로드 기능 연결 (최대 5장)
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
-private fun PhotoUploadSection(imageCount: Int) {
+private fun PhotoUploadSection(
+    imageUris: List<String>,
+    onPhotoAddClick: () -> Unit,
+    onPhotoRemoveClick: (String) -> Unit,
+) {
     Column {
         SectionLabel(
             text = "사진",
             trailing = {
                 Text(
-                    text = "$imageCount/5",
+                    text = "${imageUris.size}/$MAX_IMAGE_COUNT",
                     style = IssueTypo.Regular12.copy(color = Gray_6)
                 )
             }
         )
-        Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
-            PhotoAddBox(
-                onClick = {
-                    // TODO: 사진 선택 launcher 호출 후 viewModel에 반영
-                }
-            )
+        FlowRow(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(10.dp),
+            verticalArrangement = Arrangement.spacedBy(10.dp),
+        ) {
+            if (imageUris.size < MAX_IMAGE_COUNT) {
+                PhotoAddBox(onClick = onPhotoAddClick)
+            }
+            imageUris.forEach { uri ->
+                SelectedPhotoBox(
+                    uri = uri,
+                    onRemoveClick = { onPhotoRemoveClick(uri) },
+                )
+            }
         }
     }
 }
@@ -258,6 +293,40 @@ private fun PhotoAddBox(onClick: () -> Unit) {
             text = "사진 추가",
             style = IssueTypo.Regular12.copy(color = Gray_5)
         )
+    }
+}
+
+@Composable
+private fun SelectedPhotoBox(
+    uri: String,
+    onRemoveClick: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .size(80.dp)
+            .clip(RoundedCornerShape(12.dp))
+            .background(Gray_1)
+    ) {
+        AsyncImage(
+            model = uri,
+            contentDescription = "첨부 사진",
+            contentScale = ContentScale.Crop,
+            modifier = Modifier.fillMaxSize(),
+        )
+        IconButton(
+            onClick = onRemoveClick,
+            modifier = Modifier
+                .align(Alignment.TopEnd)
+                .size(28.dp)
+                .background(Title.copy(alpha = 0.6f), RoundedCornerShape(bottomStart = 12.dp)),
+        ) {
+            Icon(
+                imageVector = Icons.Default.Close,
+                contentDescription = "사진 삭제",
+                tint = White,
+                modifier = Modifier.size(16.dp),
+            )
+        }
     }
 }
 
@@ -399,12 +468,14 @@ private fun PinCreateScreenPreview_IssueFilled() {
                 description = "퇴근 시간대 사람이 너무 많은데 신호가 30초밖에 안 돼서 못 건너요.",
                 address = "서울 광진구 능동로 120",
                 locationName = "건국대학교 입구",
-                selectedTone = "#공손하게"
+                selectedTone = "개선요청형"
             ),
             onBackClick = {},
             onTitleChange = {},
             onDescriptionChange = {},
             onToneChange = {},
+            onPhotoAddClick = {},
+            onPhotoRemoveClick = {},
             onAiDraftClick = {},
             onSubmit = {}
         )
@@ -423,14 +494,18 @@ private fun PinCreateScreenPreview_Communication() {
                 description = "어린이대공원 근처 살아요. 가볍게 한 바퀴 도실 분 모집합니다.",
                 address = "서울 광진구 화양동",
                 locationName = "화양동 주민센터 앞",
-                selectedTone = "#친근하게"
+                selectedTone = "상황설명형"
             ),
             onBackClick = {},
             onTitleChange = {},
             onDescriptionChange = {},
             onToneChange = {},
+            onPhotoAddClick = {},
+            onPhotoRemoveClick = {},
             onAiDraftClick = {},
             onSubmit = {}
         )
     }
 }
+
+private const val MAX_IMAGE_COUNT = 5

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -68,6 +68,7 @@ fun PinCreateScreen(
     pinLng: Double,
     userLat: Double,
     userLng: Double,
+    address: String,
     onBackClick: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PinCreateViewModel = hiltViewModel()
@@ -79,8 +80,8 @@ fun PinCreateScreen(
         viewModel.addImageUris(uris.map { it.toString() })
     }
 
-    LaunchedEffect(category, pinLat, pinLng, userLat, userLng) {
-        viewModel.initialize(category, pinLat, pinLng, userLat, userLng)
+    LaunchedEffect(category, pinLat, pinLng, userLat, userLng, address) {
+        viewModel.initialize(category, pinLat, pinLng, userLat, userLng, address)
     }
 
     LaunchedEffect(Unit) {

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -72,6 +72,12 @@ fun PinCreateScreen(
         viewModel.initialize(category, pinLat, pinLng, userLat, userLng)
     }
 
+    LaunchedEffect(Unit) {
+        viewModel.createdEvents.collect {
+            onBackClick()
+        }
+    }
+
     PinCreateContent(
         category = category,
         uiState = uiState,
@@ -173,10 +179,9 @@ private fun PinCreateContent(
 
         HorizontalDivider(color = Gray_3, thickness = 1.dp)
 
-        // TODO: PinRepository.createPin 연결
         CommonButton(
             onClick = onSubmit,
-            text = "작성 완료",
+            text = if (uiState.isSubmitting) "작성 중" else "작성 완료",
             isEnabled = uiState.title.isNotBlank() &&
                 uiState.description.isNotBlank() &&
                 !uiState.isSubmitting,

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -1,11 +1,5 @@
 package com.issueissyu.fe.ui.screens.pincreate
 
-import android.Manifest
-import android.content.pm.PackageManager
-import android.widget.Toast
-import androidx.activity.compose.rememberLauncherForActivityResult
-import androidx.activity.result.PickVisualMediaRequest
-import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -28,36 +22,26 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.PhotoCamera
-import androidx.compose.material.icons.filled.PhotoLibrary
 import androidx.compose.material.icons.filled.Place
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.key
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import androidx.core.content.ContextCompat
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.issueissyu.fe.core.constants.PinImageUploadConstraints
-import com.issueissyu.fe.core.media.CapturedImageSaver
+import com.issueissyu.fe.core.media.rememberPhotoSourcePicker
 import com.issueissyu.fe.domain.model.pin.PinCategory
 import com.issueissyu.fe.ui.components.CommonButton
 import com.issueissyu.fe.ui.components.CommonTextField
@@ -76,7 +60,6 @@ import com.issueissyu.fe.ui.theme.White
 import androidx.compose.ui.tooling.preview.Preview
 import coil.compose.AsyncImage
 
-@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PinCreateScreen(
     category: PinCategory,
@@ -91,102 +74,14 @@ fun PinCreateScreen(
     viewModel: PinCreateViewModel = hiltViewModel()
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val context = LocalContext.current
-    var showPhotoSourceSheet by remember { mutableStateOf(false) }
 
-    val remainingSlots = PinImageUploadConstraints.MAX_COUNT - uiState.imageUris.size
-    val albumPickRequest = PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
-
-    var launchAlbumPicker by remember { mutableStateOf<(() -> Unit)?>(null) }
-
-    if (remainingSlots > 1) {
-        key(remainingSlots) {
-            val imagePickerLauncher = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.PickMultipleVisualMedia(maxItems = remainingSlots),
-            ) { uris ->
-                viewModel.addImageUris(uris.map { it.toString() })
-            }
-            SideEffect {
-                launchAlbumPicker = {
-                    imagePickerLauncher.launch(albumPickRequest)
-                }
-            }
-        }
-    } else if (remainingSlots == 1) {
-        key("single-album") {
-            val imagePickerLauncher = rememberLauncherForActivityResult(
-                contract = ActivityResultContracts.PickVisualMedia(),
-            ) { uri ->
-                uri?.let { picked -> viewModel.addImageUris(listOf(picked.toString())) }
-            }
-            SideEffect {
-                launchAlbumPicker = {
-                    imagePickerLauncher.launch(albumPickRequest)
-                }
-            }
-        }
-    } else {
-        SideEffect {
-            launchAlbumPicker = null
-        }
-    }
-
-    val cameraLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.TakePicturePreview(),
-    ) { bitmap ->
-        when {
-            bitmap == null -> Unit
-            else -> {
-                val uri = CapturedImageSaver.saveJpegToCache(context, bitmap, "pin-create")
-                if (uri == null) {
-                    Toast.makeText(context, "사진을 저장하지 못했습니다.", Toast.LENGTH_SHORT).show()
-                } else {
-                    viewModel.addImageUris(listOf(uri))
-                }
-            }
-        }
-    }
-
-    val cameraPermissionLauncher = rememberLauncherForActivityResult(
-        contract = ActivityResultContracts.RequestPermission(),
-    ) { granted ->
-        if (granted) {
-            cameraLauncher.launch(null)
-        } else {
-            Toast.makeText(context, "카메라 권한이 필요합니다.", Toast.LENGTH_SHORT).show()
-        }
-    }
-
-    val launchCamera = remember(cameraLauncher, cameraPermissionLauncher, context) {
-        {
-            showPhotoSourceSheet = false
-            val hasPermission = ContextCompat.checkSelfPermission(
-                context,
-                Manifest.permission.CAMERA,
-            ) == PackageManager.PERMISSION_GRANTED
-            if (hasPermission) {
-                cameraLauncher.launch(null)
-            } else {
-                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
-            }
-        }
-    }
-
-    val launchAlbum: () -> Unit = remember {
-        {
-            showPhotoSourceSheet = false
-            launchAlbumPicker?.invoke()
-            Unit
-        }
-    }
-
-    if (showPhotoSourceSheet) {
-        PhotoAddSourceBottomSheet(
-            onDismissRequest = { showPhotoSourceSheet = false },
-            onAlbumClick = launchAlbum,
-            onCameraClick = launchCamera,
-        )
-    }
+    val photoSourcePicker = rememberPhotoSourcePicker(
+        currentCount = uiState.imageUris.size,
+        maxCount = PinImageUploadConstraints.MAX_COUNT,
+        onImagesPicked = viewModel::addImageUris,
+        cameraFileNamePrefix = "pin-create",
+    )
+    photoSourcePicker.PhotoSourceBottomSheet()
 
     LaunchedEffect(category, pinLat, pinLng, userLat, userLng, address) {
         viewModel.initialize(category, pinLat, pinLng, userLat, userLng, address)
@@ -205,7 +100,7 @@ fun PinCreateScreen(
         onTitleChange = viewModel::onTitleChange,
         onDescriptionChange = viewModel::onDescriptionChange,
         onToneChange = viewModel::onToneChange,
-        onPhotoAddClick = { showPhotoSourceSheet = true },
+        onPhotoAddClick = photoSourcePicker.showSourceSheet,
         onPhotoRemoveClick = viewModel::removeImageUri,
         onSetMainImageClick = viewModel::setMainImageUri,
         onAiDraftClick = viewModel::createAiDraft,
@@ -389,72 +284,6 @@ private fun PhotoUploadSection(
                 )
             }
         }
-    }
-}
-
-@OptIn(ExperimentalMaterial3Api::class)
-@Composable
-private fun PhotoAddSourceBottomSheet(
-    onDismissRequest: () -> Unit,
-    onAlbumClick: () -> Unit,
-    onCameraClick: () -> Unit,
-) {
-    ModalBottomSheet(
-        onDismissRequest = onDismissRequest,
-        containerColor = White,
-        shape = RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp),
-        dragHandle = null,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp, vertical = 16.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp),
-        ) {
-            Text(
-                text = "사진 추가",
-                style = IssueTypo.Bold18.copy(color = Title),
-            )
-            PhotoSourceOptionRow(
-                icon = Icons.Default.PhotoLibrary,
-                label = "앨범에서 선택",
-                onClick = onAlbumClick,
-            )
-            PhotoSourceOptionRow(
-                icon = Icons.Default.PhotoCamera,
-                label = "카메라로 촬영",
-                onClick = onCameraClick,
-            )
-            Spacer(modifier = Modifier.height(8.dp))
-        }
-    }
-}
-
-@Composable
-private fun PhotoSourceOptionRow(
-    icon: androidx.compose.ui.graphics.vector.ImageVector,
-    label: String,
-    onClick: () -> Unit,
-) {
-    Row(
-        modifier = Modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 12.dp, vertical = 14.dp),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(12.dp),
-    ) {
-        Icon(
-            imageVector = icon,
-            contentDescription = null,
-            tint = Gray_5,
-            modifier = Modifier.size(24.dp),
-        )
-        Text(
-            text = label,
-            style = IssueTypo.Regular15.copy(color = TextColor),
-        )
     }
 }
 

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateScreen.kt
@@ -71,6 +71,7 @@ fun PinCreateScreen(
     userLng: Double,
     address: String,
     onBackClick: () -> Unit,
+    onCreated: (String) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: PinCreateViewModel = hiltViewModel()
 ) {
@@ -88,8 +89,8 @@ fun PinCreateScreen(
     }
 
     LaunchedEffect(Unit) {
-        viewModel.createdEvents.collect {
-            onBackClick()
+        viewModel.createdEvents.collect { createdPinId ->
+            onCreated(createdPinId)
         }
     }
 

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -1,13 +1,17 @@
 package com.issueissyu.fe.ui.screens.pincreate
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.issueissyu.fe.core.constants.PinImageUploadConstraints
+import com.issueissyu.fe.core.media.PinImageUploadValidator
 import com.issueissyu.fe.domain.model.pin.CreatePinRequest
 import com.issueissyu.fe.domain.model.pin.PinCategory
 import com.issueissyu.fe.domain.model.pin.PinCoordinate
 import com.issueissyu.fe.domain.repository.IssueRepository
 import com.issueissyu.fe.domain.repository.PinRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -28,6 +32,7 @@ data class PinCreateUiState(
     val address: String = "",
     val locationName: String? = null,
     val imageUris: List<String> = emptyList(),
+    val mainImageUri: String? = null,
     val selectedTone: String? = null,
     val isSubmitting: Boolean = false,
     val isGeneratingAiContent: Boolean = false,
@@ -38,6 +43,7 @@ data class PinCreateUiState(
 class PinCreateViewModel @Inject constructor(
     private val issueRepository: IssueRepository,
     private val pinRepository: PinRepository,
+    @ApplicationContext private val context: Context,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PinCreateUiState())
@@ -91,25 +97,52 @@ class PinCreateViewModel @Inject constructor(
     fun addImageUris(uris: List<String>) {
         if (uris.isEmpty()) return
 
-        _uiState.update { state ->
-            val merged = (state.imageUris + uris)
-                .distinct()
-                .take(MAX_IMAGE_COUNT)
-            state.copy(
+        val state = _uiState.value
+        if (state.imageUris.size + uris.size > PinImageUploadConstraints.MAX_COUNT) {
+            _uiState.update {
+                it.copy(errorMessage = "사진은 최대 ${PinImageUploadConstraints.MAX_COUNT}장까지 첨부할 수 있습니다.")
+            }
+            return
+        }
+
+        val merged = (state.imageUris + uris)
+            .distinct()
+            .take(PinImageUploadConstraints.MAX_COUNT)
+
+        PinImageUploadValidator.validate(context, merged).onFailure { error ->
+            _uiState.update {
+                it.copy(
+                    errorMessage = error.message?.takeIf { message -> message.isNotBlank() }
+                        ?: "첨부한 사진을 확인할 수 없습니다.",
+                )
+            }
+            return
+        }
+
+        _uiState.update {
+            it.copy(
                 imageUris = merged,
-                errorMessage = if (state.imageUris.size + uris.size > MAX_IMAGE_COUNT) {
-                    "사진은 최대 ${MAX_IMAGE_COUNT}장까지 첨부할 수 있습니다."
-                } else {
-                    state.errorMessage
-                },
+                mainImageUri = it.mainImageUri?.takeIf { mainUri -> mainUri in merged } ?: merged.firstOrNull(),
+                errorMessage = null,
             )
         }
     }
 
     fun removeImageUri(uri: String) {
         _uiState.update { state ->
-            state.copy(imageUris = state.imageUris.filterNot { it == uri })
+            val remaining = state.imageUris.filterNot { it == uri }
+            state.copy(
+                imageUris = remaining,
+                mainImageUri = state.mainImageUri
+                    ?.takeIf { mainUri -> mainUri in remaining }
+                    ?: remaining.firstOrNull(),
+            )
         }
+    }
+
+    fun setMainImageUri(uri: String) {
+        if (uri !in _uiState.value.imageUris) return
+        _uiState.update { it.copy(mainImageUri = uri) }
     }
 
     fun createAiDraft() {
@@ -193,6 +226,16 @@ class PinCreateViewModel @Inject constructor(
             }
         }
 
+        PinImageUploadValidator.validate(context, state.imageUris).onFailure { error ->
+            _uiState.update {
+                it.copy(
+                    errorMessage = error.message?.takeIf { message -> message.isNotBlank() }
+                        ?: "첨부한 사진을 확인할 수 없습니다.",
+                )
+            }
+            return
+        }
+
         viewModelScope.launch {
             _uiState.update { it.copy(isSubmitting = true, errorMessage = null) }
             pinRepository.createPin(
@@ -207,6 +250,7 @@ class PinCreateViewModel @Inject constructor(
                     address = state.address,
                     locationName = state.locationName,
                     imageUris = state.imageUris,
+                    mainImageUri = state.mainImageUri,
                     tone = state.selectedTone ?: DEFAULT_AI_TONE,
                 )
             ).onSuccess {
@@ -225,6 +269,5 @@ class PinCreateViewModel @Inject constructor(
 
     companion object {
         private const val DEFAULT_AI_TONE = "없음"
-        private const val MAX_IMAGE_COUNT = 5
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -51,25 +51,27 @@ class PinCreateViewModel @Inject constructor(
         pinLat: Double,
         pinLng: Double,
         userLat: Double,
-        userLng: Double
+        userLng: Double,
+        address: String,
     ) {
         val current = _uiState.value
         if (current.category == category &&
             current.pinLat == pinLat &&
             current.pinLng == pinLng &&
             current.userLat == userLat &&
-            current.userLng == userLng
+            current.userLng == userLng &&
+            current.address == address
         ) {
             return
         }
-        // TODO: 좌표 기반 주소 변환 결과를 address/locationName으로 표시
         _uiState.update {
             it.copy(
                 category = category,
                 pinLat = pinLat,
                 pinLng = pinLng,
                 userLat = userLat,
-                userLng = userLng
+                userLng = userLng,
+                address = address,
             )
         }
     }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -34,7 +34,9 @@ data class PinCreateUiState(
     val locationName: String? = null,
     val imageUris: List<String> = emptyList(),
     val mainImageUri: String? = null,
+    val toneOptions: List<String> = emptyList(),
     val selectedTone: String? = null,
+    val isLoadingToneOptions: Boolean = false,
     val isSubmitting: Boolean = false,
     val isGeneratingAiContent: Boolean = false,
     val errorMessage: String? = null
@@ -82,6 +84,37 @@ class PinCreateViewModel @Inject constructor(
                 userLng = userLng,
                 address = address,
             )
+        }
+        if (category == PinCategory.ISSUE) {
+            loadIssueToneTypes()
+        }
+    }
+
+    private fun loadIssueToneTypes() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoadingToneOptions = true) }
+            issueRepository.getIssueToneTypes()
+                .onSuccess { tones ->
+                    val labels = tones.map { it.label }
+                    _uiState.update { state ->
+                        state.copy(
+                            toneOptions = labels,
+                            selectedTone = state.selectedTone?.takeIf { it in labels }
+                                ?: labels.firstOrNull(),
+                            isLoadingToneOptions = false,
+                        )
+                    }
+                }
+                .onFailure {
+                    _uiState.update { state ->
+                        state.copy(
+                            toneOptions = FALLBACK_TONE_OPTIONS,
+                            selectedTone = state.selectedTone?.takeIf { it in FALLBACK_TONE_OPTIONS }
+                                ?: DEFAULT_AI_TONE,
+                            isLoadingToneOptions = false,
+                        )
+                    }
+                }
         }
     }
 
@@ -303,5 +336,13 @@ class PinCreateViewModel @Inject constructor(
 
     companion object {
         private const val DEFAULT_AI_TONE = "없음"
+        private val FALLBACK_TONE_OPTIONS = listOf(
+            "없음",
+            "한줄요약형",
+            "상황설명형",
+            "개선요청형",
+            "긴급요청형",
+            "불편호소형",
+        )
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -49,7 +49,7 @@ class PinCreateViewModel @Inject constructor(
     private val _uiState = MutableStateFlow(PinCreateUiState())
     val uiState: StateFlow<PinCreateUiState> = _uiState.asStateFlow()
 
-    private val _createdEvents = MutableSharedFlow<Unit>()
+    private val _createdEvents = MutableSharedFlow<String>()
     val createdEvents = _createdEvents.asSharedFlow()
 
     fun initialize(
@@ -224,6 +224,10 @@ class PinCreateViewModel @Inject constructor(
                 _uiState.update { it.copy(errorMessage = "핀 위치 정보를 확인하지 못했습니다.") }
                 return
             }
+            category == PinCategory.ISSUE && state.imageUris.isEmpty() -> {
+                _uiState.update { it.copy(errorMessage = "이슈 핀은 사진을 최소 1장 첨부해야 합니다.") }
+                return
+            }
         }
 
         PinImageUploadValidator.validate(context, state.imageUris).onFailure { error ->
@@ -253,9 +257,9 @@ class PinCreateViewModel @Inject constructor(
                     mainImageUri = state.mainImageUri,
                     tone = state.selectedTone ?: DEFAULT_AI_TONE,
                 )
-            ).onSuccess {
+            ).onSuccess { createdPin ->
                 _uiState.update { it.copy(isSubmitting = false, errorMessage = null) }
-                _createdEvents.emit(Unit)
+                _createdEvents.emit(createdPin.id)
             }.onFailure { e ->
                 _uiState.update {
                     it.copy(

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -1,12 +1,15 @@
 package com.issueissyu.fe.ui.screens.pincreate
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import com.issueissyu.fe.domain.model.pin.PinCategory
+import com.issueissyu.fe.domain.repository.IssueRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 data class PinCreateUiState(
@@ -27,7 +30,9 @@ data class PinCreateUiState(
 )
 
 @HiltViewModel
-class PinCreateViewModel @Inject constructor() : ViewModel() {
+class PinCreateViewModel @Inject constructor(
+    private val issueRepository: IssueRepository,
+) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PinCreateUiState())
     val uiState: StateFlow<PinCreateUiState> = _uiState.asStateFlow()
@@ -72,8 +77,67 @@ class PinCreateViewModel @Inject constructor() : ViewModel() {
         _uiState.update { it.copy(selectedTone = value) }
     }
 
+    fun createAiDraft() {
+        val state = _uiState.value
+        if (state.category != PinCategory.ISSUE || state.isGeneratingAiContent) return
+
+        val pinLat = state.pinLat
+        val pinLng = state.pinLng
+        when {
+            state.title.isBlank() -> {
+                _uiState.update { it.copy(errorMessage = "제목을 먼저 입력해주세요.") }
+                return
+            }
+            state.description.isBlank() -> {
+                _uiState.update { it.copy(errorMessage = "상세 설명을 먼저 입력해주세요.") }
+                return
+            }
+            pinLat == null || pinLng == null -> {
+                _uiState.update { it.copy(errorMessage = "핀 위치 정보를 확인하지 못했습니다.") }
+                return
+            }
+        }
+
+        viewModelScope.launch {
+            _uiState.update {
+                it.copy(
+                    isGeneratingAiContent = true,
+                    errorMessage = null,
+                )
+            }
+
+            issueRepository.createIssueAiDraft(
+                title = state.title,
+                content = state.description,
+                tone = state.selectedTone ?: DEFAULT_AI_TONE,
+                latitude = pinLat,
+                longitude = pinLng,
+            ).onSuccess { draft ->
+                _uiState.update {
+                    it.copy(
+                        title = draft.title?.takeIf { title -> title.isNotBlank() } ?: it.title,
+                        description = draft.content.orEmpty(),
+                        isGeneratingAiContent = false,
+                        errorMessage = null,
+                    )
+                }
+            }.onFailure { e ->
+                _uiState.update {
+                    it.copy(
+                        isGeneratingAiContent = false,
+                        errorMessage = e.message?.takeIf { message -> message.isNotBlank() } ?: "AI 글쓰기에 실패했습니다.",
+                    )
+                }
+            }
+        }
+    }
+
     // TODO: PinRepository.createPin 연결 (isSubmitting / errorMessage 흐름 포함)
     fun submitPin() {
         // no-op
+    }
+
+    companion object {
+        private const val DEFAULT_AI_TONE = "없음"
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -7,6 +7,7 @@ import com.issueissyu.fe.core.constants.PinImageUploadConstraints
 import com.issueissyu.fe.core.media.PinImageUploadValidator
 import com.issueissyu.fe.domain.model.pin.CreatePinRequest
 import com.issueissyu.fe.domain.model.pin.PinCategory
+import com.issueissyu.fe.domain.model.pin.PinCreateException
 import com.issueissyu.fe.domain.model.pin.PinCoordinate
 import com.issueissyu.fe.domain.repository.IssueRepository
 import com.issueissyu.fe.domain.repository.PinRepository
@@ -51,6 +52,8 @@ class PinCreateViewModel @Inject constructor(
 
     private val _createdEvents = MutableSharedFlow<String>()
     val createdEvents = _createdEvents.asSharedFlow()
+
+    private var lastFailedImageFingerprint: String? = null
 
     fun initialize(
         category: PinCategory,
@@ -126,6 +129,7 @@ class PinCreateViewModel @Inject constructor(
                 errorMessage = null,
             )
         }
+        clearImageUploadFailureTracking()
     }
 
     fun removeImageUri(uri: String) {
@@ -138,6 +142,7 @@ class PinCreateViewModel @Inject constructor(
                     ?: remaining.firstOrNull(),
             )
         }
+        clearImageUploadFailureTracking()
     }
 
     fun setMainImageUri(uri: String) {
@@ -258,17 +263,42 @@ class PinCreateViewModel @Inject constructor(
                     tone = state.selectedTone ?: DEFAULT_AI_TONE,
                 )
             ).onSuccess { createdPin ->
+                clearImageUploadFailureTracking()
                 _uiState.update { it.copy(isSubmitting = false, errorMessage = null) }
                 _createdEvents.emit(createdPin.id)
             }.onFailure { e ->
                 _uiState.update {
                     it.copy(
                         isSubmitting = false,
-                        errorMessage = e.message?.takeIf { message -> message.isNotBlank() } ?: "핀 생성에 실패했습니다.",
+                        errorMessage = resolveSubmitErrorMessage(e, state.imageUris),
                     )
                 }
             }
         }
+    }
+
+    private fun resolveSubmitErrorMessage(error: Throwable, imageUris: List<String>): String {
+        val pinCreateError = error as? PinCreateException
+        val fingerprint = imageUris.sorted().joinToString("|")
+        val isImageRelated = pinCreateError?.isImageRelated == true
+        val isRepeatImageFailure = isImageRelated &&
+            fingerprint.isNotEmpty() &&
+            fingerprint == lastFailedImageFingerprint
+
+        if (isImageRelated && fingerprint.isNotEmpty()) {
+            lastFailedImageFingerprint = fingerprint
+        }
+
+        return when {
+            isRepeatImageFailure ->
+                "선택한 사진으로 등록에 실패했습니다. 다른 사진으로 다시 시도해주세요."
+            else ->
+                error.message?.takeIf { message -> message.isNotBlank() } ?: "핀 생성에 실패했습니다."
+        }
+    }
+
+    private fun clearImageUploadFailureTracking() {
+        lastFailedImageFingerprint = null
     }
 
     companion object {

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -86,6 +86,30 @@ class PinCreateViewModel @Inject constructor(
         _uiState.update { it.copy(selectedTone = value) }
     }
 
+    fun addImageUris(uris: List<String>) {
+        if (uris.isEmpty()) return
+
+        _uiState.update { state ->
+            val merged = (state.imageUris + uris)
+                .distinct()
+                .take(MAX_IMAGE_COUNT)
+            state.copy(
+                imageUris = merged,
+                errorMessage = if (state.imageUris.size + uris.size > MAX_IMAGE_COUNT) {
+                    "사진은 최대 ${MAX_IMAGE_COUNT}장까지 첨부할 수 있습니다."
+                } else {
+                    state.errorMessage
+                },
+            )
+        }
+    }
+
+    fun removeImageUri(uri: String) {
+        _uiState.update { state ->
+            state.copy(imageUris = state.imageUris.filterNot { it == uri })
+        }
+    }
+
     fun createAiDraft() {
         val state = _uiState.value
         if (state.category != PinCategory.ISSUE || state.isGeneratingAiContent) return
@@ -199,5 +223,6 @@ class PinCreateViewModel @Inject constructor(
 
     companion object {
         private const val DEFAULT_AI_TONE = "없음"
+        private const val MAX_IMAGE_COUNT = 5
     }
 }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -19,7 +19,9 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 data class PinCreateUiState(
@@ -133,36 +135,55 @@ class PinCreateViewModel @Inject constructor(
     fun addImageUris(uris: List<String>) {
         if (uris.isEmpty()) return
 
-        val state = _uiState.value
-        if (state.imageUris.size + uris.size > PinImageUploadConstraints.MAX_COUNT) {
+        val snapshot = _uiState.value
+        val remaining = PinImageUploadConstraints.MAX_COUNT - snapshot.imageUris.size
+        if (remaining <= 0) {
             _uiState.update {
                 it.copy(errorMessage = "사진은 최대 ${PinImageUploadConstraints.MAX_COUNT}장까지 첨부할 수 있습니다.")
             }
             return
         }
 
-        val merged = (state.imageUris + uris)
-            .distinct()
-            .take(PinImageUploadConstraints.MAX_COUNT)
+        val newUris = uris
+            .filter { uri -> uri !in snapshot.imageUris }
+            .take(remaining)
+        if (newUris.isEmpty()) return
 
-        PinImageUploadValidator.validate(context, merged).onFailure { error ->
-            _uiState.update {
-                it.copy(
-                    errorMessage = error.message?.takeIf { message -> message.isNotBlank() }
-                        ?: "첨부한 사진을 확인할 수 없습니다.",
+        val merged = snapshot.imageUris + newUris
+
+        viewModelScope.launch {
+            val validation = runCatching {
+                withContext(Dispatchers.IO) {
+                    PinImageUploadValidator.validate(context, merged)
+                }
+            }.getOrElse { error ->
+                Result.failure(
+                    IllegalArgumentException(
+                        error.message?.takeIf { message -> message.isNotBlank() }
+                            ?: "첨부한 사진을 확인할 수 없습니다.",
+                    ),
                 )
             }
-            return
-        }
 
-        _uiState.update {
-            it.copy(
-                imageUris = merged,
-                mainImageUri = it.mainImageUri?.takeIf { mainUri -> mainUri in merged } ?: merged.firstOrNull(),
-                errorMessage = null,
-            )
+            validation.onFailure { error ->
+                _uiState.update {
+                    it.copy(
+                        errorMessage = error.message?.takeIf { message -> message.isNotBlank() }
+                            ?: "첨부한 사진을 확인할 수 없습니다.",
+                    )
+                }
+                return@launch
+            }
+
+            _uiState.update {
+                it.copy(
+                    imageUris = merged,
+                    mainImageUri = it.mainImageUri?.takeIf { mainUri -> mainUri in merged } ?: merged.firstOrNull(),
+                    errorMessage = null,
+                )
+            }
+            clearImageUploadFailureTracking()
         }
-        clearImageUploadFailureTracking()
     }
 
     fun removeImageUri(uri: String) {
@@ -268,17 +289,30 @@ class PinCreateViewModel @Inject constructor(
             }
         }
 
-        PinImageUploadValidator.validate(context, state.imageUris).onFailure { error ->
-            _uiState.update {
-                it.copy(
-                    errorMessage = error.message?.takeIf { message -> message.isNotBlank() }
-                        ?: "첨부한 사진을 확인할 수 없습니다.",
+        viewModelScope.launch {
+            val validation = runCatching {
+                withContext(Dispatchers.IO) {
+                    PinImageUploadValidator.validate(context, state.imageUris)
+                }
+            }.getOrElse { error ->
+                Result.failure(
+                    IllegalArgumentException(
+                        error.message?.takeIf { message -> message.isNotBlank() }
+                            ?: "첨부한 사진을 확인할 수 없습니다.",
+                    ),
                 )
             }
-            return
-        }
 
-        viewModelScope.launch {
+            validation.onFailure { error ->
+                _uiState.update {
+                    it.copy(
+                        errorMessage = error.message?.takeIf { message -> message.isNotBlank() }
+                            ?: "첨부한 사진을 확인할 수 없습니다.",
+                    )
+                }
+                return@launch
+            }
+
             _uiState.update { it.copy(isSubmitting = true, errorMessage = null) }
             pinRepository.createPin(
                 CreatePinRequest(

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pincreate/PinCreateViewModel.kt
@@ -2,10 +2,15 @@ package com.issueissyu.fe.ui.screens.pincreate
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.issueissyu.fe.domain.model.pin.CreatePinRequest
 import com.issueissyu.fe.domain.model.pin.PinCategory
+import com.issueissyu.fe.domain.model.pin.PinCoordinate
 import com.issueissyu.fe.domain.repository.IssueRepository
+import com.issueissyu.fe.domain.repository.PinRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -32,10 +37,14 @@ data class PinCreateUiState(
 @HiltViewModel
 class PinCreateViewModel @Inject constructor(
     private val issueRepository: IssueRepository,
+    private val pinRepository: PinRepository,
 ) : ViewModel() {
 
     private val _uiState = MutableStateFlow(PinCreateUiState())
     val uiState: StateFlow<PinCreateUiState> = _uiState.asStateFlow()
+
+    private val _createdEvents = MutableSharedFlow<Unit>()
+    val createdEvents = _createdEvents.asSharedFlow()
 
     fun initialize(
         category: PinCategory,
@@ -132,9 +141,60 @@ class PinCreateViewModel @Inject constructor(
         }
     }
 
-    // TODO: PinRepository.createPin 연결 (isSubmitting / errorMessage 흐름 포함)
     fun submitPin() {
-        // no-op
+        val state = _uiState.value
+        if (state.isSubmitting) return
+
+        val category = state.category
+        val pinLat = state.pinLat
+        val pinLng = state.pinLng
+        when {
+            category == null -> {
+                _uiState.update { it.copy(errorMessage = "핀 종류를 확인하지 못했습니다.") }
+                return
+            }
+            state.title.isBlank() -> {
+                _uiState.update { it.copy(errorMessage = "제목을 입력해주세요.") }
+                return
+            }
+            state.description.isBlank() -> {
+                _uiState.update { it.copy(errorMessage = "상세 설명을 입력해주세요.") }
+                return
+            }
+            pinLat == null || pinLng == null -> {
+                _uiState.update { it.copy(errorMessage = "핀 위치 정보를 확인하지 못했습니다.") }
+                return
+            }
+        }
+
+        viewModelScope.launch {
+            _uiState.update { it.copy(isSubmitting = true, errorMessage = null) }
+            pinRepository.createPin(
+                CreatePinRequest(
+                    category = category,
+                    title = state.title,
+                    description = state.description,
+                    coordinate = PinCoordinate(
+                        latitude = pinLat,
+                        longitude = pinLng,
+                    ),
+                    address = state.address,
+                    locationName = state.locationName,
+                    imageUris = state.imageUris,
+                    tone = state.selectedTone ?: DEFAULT_AI_TONE,
+                )
+            ).onSuccess {
+                _uiState.update { it.copy(isSubmitting = false, errorMessage = null) }
+                _createdEvents.emit(Unit)
+            }.onFailure { e ->
+                _uiState.update {
+                    it.copy(
+                        isSubmitting = false,
+                        errorMessage = e.message?.takeIf { message -> message.isNotBlank() } ?: "핀 생성에 실패했습니다.",
+                    )
+                }
+            }
+        }
     }
 
     companion object {

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pindetail/PinDetailScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pindetail/PinDetailScreen.kt
@@ -1,9 +1,7 @@
 package com.issueissyu.fe.ui.screens.pindetail
 
 import android.Manifest
-import android.content.Context
 import android.content.pm.PackageManager
-import android.graphics.Bitmap
 import android.widget.Toast
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
@@ -47,7 +45,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
 import androidx.core.content.ContextCompat
-import androidx.core.net.toUri
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
@@ -56,6 +53,7 @@ import com.issueissyu.fe.data.sample.PinSamples
 import com.issueissyu.fe.domain.model.pin.IssuePinDetail
 import com.issueissyu.fe.domain.model.pin.Pin
 import com.issueissyu.fe.domain.model.pin.toPostSympathyContent
+import com.issueissyu.fe.core.media.CapturedImageSaver
 import com.issueissyu.fe.ui.components.EmojiReactionBottomSheet
 import com.issueissyu.fe.ui.components.IssueissyuTopAppBar
 import com.issueissyu.fe.ui.theme.BrandColor
@@ -66,8 +64,6 @@ import com.issueissyu.fe.ui.theme.IssueissyuTheme
 import com.issueissyu.fe.ui.theme.Orange
 import com.issueissyu.fe.ui.theme.Title
 import com.issueissyu.fe.ui.theme.White
-import java.io.File
-import java.io.FileOutputStream
 
 internal const val PIN_DETAIL_REFRESH_KEY = "pin_detail_refresh"
 
@@ -89,7 +85,7 @@ fun PinDetailScreen(
     val cameraLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.TakePicturePreview()
     ) { bitmap ->
-        val proofUri = bitmap?.let { saveResolutionProofBitmap(context, it) }
+        val proofUri = bitmap?.let { CapturedImageSaver.saveJpegToCache(context, it, "resolution-proof") }
         if (proofUri == null) {
             Toast.makeText(context, "사진 촬영이 취소되었습니다.", Toast.LENGTH_SHORT).show()
         } else {
@@ -517,22 +513,6 @@ private fun PinDetailTab.label(): String = when (this) {
     PinDetailTab.HOME -> "홈"
     PinDetailTab.POST -> "포스트"
     PinDetailTab.RESOLUTION -> "해결하기"
-}
-
-private fun saveResolutionProofBitmap(
-    context: Context,
-    bitmap: Bitmap,
-): String? {
-    return runCatching {
-        val file = File(
-            context.cacheDir,
-            "resolution-proof-${System.currentTimeMillis()}.jpg"
-        )
-        FileOutputStream(file).use { output ->
-            bitmap.compress(Bitmap.CompressFormat.JPEG, 92, output)
-        }
-        file.toUri().toString()
-    }.getOrNull()
 }
 
 @Preview(showBackground = true, heightDp = 900)

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pindetail/PinDetailViewModel.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pindetail/PinDetailViewModel.kt
@@ -21,8 +21,10 @@ import com.issueissyu.fe.domain.model.pin.ResolutionStatus
 import com.issueissyu.fe.domain.model.pin.toPostSympathyContent
 import com.issueissyu.fe.domain.model.pin.withHomeFallback
 import com.issueissyu.fe.domain.repository.PinRepository
+import com.issueissyu.fe.core.issue.IssueReliabilityPolling
 import com.issueissyu.fe.domain.usecase.issue.GetIssueReliabilityUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -92,6 +94,8 @@ class PinDetailViewModel @Inject constructor(
 
     private var routePinId: Long? = null
     private var emojiImageById: Map<Long, String> = emptyMap()
+    private var issueReliabilityJob: Job? = null
+    private var observedReliabilityPinId: Long? = null
 
     val currentUserId: String?
         get() = tokenManager.getCurrentUserUuid()
@@ -103,6 +107,9 @@ class PinDetailViewModel @Inject constructor(
             return
         }
         routePinId = id
+        issueReliabilityJob?.cancel()
+        issueReliabilityJob = null
+        observedReliabilityPinId = null
 
         viewModelScope.launch {
             _uiState.update {
@@ -133,6 +140,7 @@ class PinDetailViewModel @Inject constructor(
                     }
                     loadPostTab(id)
                     if (pin.detail is IssuePinDetail) {
+                        startIssueReliabilityObservation(id)
                         viewModelScope.launch {
                             refreshResolutionTab(id, currentUserId)
                         }
@@ -202,6 +210,9 @@ class PinDetailViewModel @Inject constructor(
             }
         } else if (tab == PinDetailTab.RESOLUTION) {
             resolvePinId()?.let { pinId ->
+                if (_uiState.value.pin?.detail is IssuePinDetail) {
+                    resumeIssueReliabilityObservationIfNeeded(pinId)
+                }
                 viewModelScope.launch {
                     refreshResolutionTab(pinId, currentUserId)
                 }
@@ -209,12 +220,53 @@ class PinDetailViewModel @Inject constructor(
         }
     }
 
+    private fun resumeIssueReliabilityObservationIfNeeded(pinId: Long) {
+        when (_uiState.value.reliabilityStatus) {
+            null,
+            IssueReliabilityStatus.PENDING,
+            -> startIssueReliabilityObservation(pinId, resetUi = false)
+            IssueReliabilityStatus.COMPLETED,
+            IssueReliabilityStatus.FAILED,
+            -> Unit
+        }
+    }
+
+    private fun startIssueReliabilityObservation(pinId: Long, resetUi: Boolean = true) {
+        val isNewPin = observedReliabilityPinId != pinId
+        observedReliabilityPinId = pinId
+        issueReliabilityJob?.cancel()
+        issueReliabilityJob = viewModelScope.launch {
+            if (resetUi || isNewPin) {
+                _uiState.update {
+                    it.copy(
+                        reliabilityScore = null,
+                        reliabilityReason = null,
+                        reliabilityStatus = IssueReliabilityStatus.PENDING,
+                    )
+                }
+            }
+            IssueReliabilityPolling.fetchWithPolling(
+                fetch = { getIssueReliabilityUseCase(pinId) },
+                onUpdate = { reliability -> applyIssueReliability(reliability) },
+            )
+        }
+    }
+
+    private fun applyIssueReliability(reliability: IssueReliability) {
+        if (observedReliabilityPinId != reliability.pinId) return
+        _uiState.update {
+            it.copy(
+                reliabilityScore = reliability.score,
+                reliabilityReason = reliability.reason,
+                reliabilityStatus = reliability.status,
+            )
+        }
+    }
+
     private suspend fun refreshResolutionTab(pinId: Long, currentUserId: String?) {
         var solveInfo: PinSolveInfo? = null
         var problemSolverInfo: ProblemSolverInfo? = null
         var petitionStatusInfo: PetitionStatusInfo? = null
-        var issueReliability: IssueReliability? = null
-        var issueReliabilityFailed = false
 
         pinRepository.getPinSolve(pinId)
             .onSuccess { solveInfo = it }
@@ -236,35 +288,22 @@ class PinDetailViewModel @Inject constructor(
                 }
         }
 
-        getIssueReliabilityUseCase(pinId)
-            .onSuccess { issueReliability = it }
-            .onFailure { issueReliabilityFailed = true }
-
         val hasResolutionData = solveInfo != null ||
             problemSolverInfo != null ||
             petitionStatusInfo != null
-        if (!hasResolutionData && issueReliability == null && !issueReliabilityFailed) return
+        if (!hasResolutionData) return
 
         _uiState.update { state ->
-            val updatedPin = if (hasResolutionData) {
-                val currentPin = state.pin ?: return@update state
-                val currentUser = buildResolutionCurrentUser(currentPin)
-                val resolutionUpdatedPin = currentPin.withResolutionApiState(
-                    currentUserId = currentUserId,
-                    currentUser = currentUser,
-                    solveInfo = solveInfo,
-                    problemSolverInfo = problemSolverInfo,
-                )
-                resolutionUpdatedPin.withPetitionApiState(petitionStatusInfo)
-            } else {
-                state.pin
-            }
+            val currentPin = state.pin ?: return@update state
+            val currentUser = buildResolutionCurrentUser(currentPin)
+            val resolutionUpdatedPin = currentPin.withResolutionApiState(
+                currentUserId = currentUserId,
+                currentUser = currentUser,
+                solveInfo = solveInfo,
+                problemSolverInfo = problemSolverInfo,
+            )
             state.copy(
-                pin = updatedPin,
-                reliabilityScore = issueReliability?.score,
-                reliabilityReason = issueReliability?.reason,
-                reliabilityStatus = issueReliability?.status
-                    ?: if (issueReliabilityFailed) IssueReliabilityStatus.FAILED else null,
+                pin = resolutionUpdatedPin.withPetitionApiState(petitionStatusInfo),
             )
         }
     }


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #53 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
- 이슈·소통 핀 생성 API 연동
- 사진(앨범·카메라) 추가
- AI 글쓰기
- 신뢰도 폴링
- 지도 공지 배너 UI 조정

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

사진 picker 공용화(rememberPhotoSourcePicker) 사용법:

val photoSourcePicker = rememberPhotoSourcePicker(
    currentCount = /* 현재 첨부된 사진 수 */,
    maxCount = /* 최대 장수 */,
    onImagesPicked = { uris -> /* 선택·촬영된 uri 목록 처리 */ },
    cameraFileNamePrefix = "고유-접두사", // 캐시 파일명용
)
photoSourcePicker.PhotoSourceBottomSheet() // 화면 Composable 안에 배치
// 트리거 버튼 onClick
photoSourcePicker.showSourceSheet()
currentCount / maxCount로 남은 슬롯에 맞게 앨범 피커가 자동 분기됩니다 (다중 ↔ 단일).
바텀시트 UI만 필요하면 PhotoAddSourceBottomSheet를 직접 써도 됩니다.
현재는 핀 작성에만 연결되어 있고, 시민해결사·핀 수정은 후속 PR에서 hook만 import하면 됩니다.