### PR TITLE
[FEAT] 핀 카드 UI 조정 및 커뮤니티 버튼 연결

### DIFF
--- a/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/navigation/AppNavGraph.kt
@@ -457,6 +457,9 @@ fun AppNavGraph(
                     onReportClick = { reportPinId ->
                         navController.navigate(AppDestinations.pinReportRoute(reportPinId))
                     },
+                    onCommunityClick = { communityId ->
+                        navController.navigate(AppDestinations.communityDetailRoute(communityId))
+                    },
                 )
             }
         }

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/MapScreen.kt
@@ -231,6 +231,11 @@ fun MapScreen(
                 this.map = naverMap
                 setOnClickListener {
                     viewModel.selectPinById(mapPin.pinId)
+                    naverMap.moveCamera(
+                        CameraUpdate
+                            .scrollTo(mapPin.coordinate.toLatLng())
+                            .animate(CameraAnimation.Easing)
+                    )
                     true
                 }
             }
@@ -529,14 +534,6 @@ fun MapScreen(
                     )
                 }
             }
-        }
-
-        if (selectedPin != null && !isLocationSelectionMode) {
-            Box(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .clickable { viewModel.clearSelectedPin() }
-            )
         }
 
         selectedPin?.takeUnless { isLocationSelectionMode }?.let { pin ->

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/PinSummaryCard.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/PinSummaryCard.kt
@@ -38,6 +38,7 @@ import com.issueissyu.fe.domain.model.pin.ResolutionStatus
 import com.issueissyu.fe.domain.model.pin.ShopPinDetail
 import com.issueissyu.fe.domain.model.pin.canEditBy
 import com.issueissyu.fe.ui.components.CompactSympathyButton
+import com.issueissyu.fe.ui.components.ProfileImageFrame
 import com.issueissyu.fe.ui.theme.*
 
 @Composable
@@ -90,6 +91,7 @@ fun PinSummaryCard(
 
                     // 2. 장소 + 해결 상태
                     Row(
+                        modifier = Modifier.fillMaxWidth(),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
                         Icon(
@@ -100,11 +102,11 @@ fun PinSummaryCard(
                         )
                         Spacer(modifier = Modifier.width(4.dp))
                         Text(
-                            text = pin.locationName ?: pin.address,
+                            text = (pin.locationName ?: pin.address).toSummaryAddress(),
                             style = IssueTypo.Regular12.copy(color = Gray_7),
                             maxLines = 1,
                             overflow = TextOverflow.Ellipsis,
-                            modifier = Modifier.widthIn(max = 190.dp)
+                            modifier = Modifier.weight(1f)
                         )
 
                         val issueDetail = pin.detail as? IssuePinDetail
@@ -124,11 +126,10 @@ fun PinSummaryCard(
                     ) {
                         when (val detail = pin.detail) {
                             is IssuePinDetail -> {
-                                Box(
-                                    modifier = Modifier
-                                        .size(24.dp)
-                                        .clip(CircleShape)
-                                        .background(Gray_3)
+                                ProfileImageFrame(
+                                    size = 24.dp,
+                                    imageUrl = detail.writer.imageUrl,
+                                    borderWidth = 1.dp,
                                 )
                                 Spacer(modifier = Modifier.width(6.dp))
                                 Text(
@@ -166,11 +167,10 @@ fun PinSummaryCard(
                                 )
                             }
                             is CommunicationPinDetail -> {
-                                Box(
-                                    modifier = Modifier
-                                        .size(24.dp)
-                                        .clip(CircleShape)
-                                        .background(Gray_3)
+                                ProfileImageFrame(
+                                    size = 24.dp,
+                                    imageUrl = detail.writer.imageUrl,
+                                    borderWidth = 1.dp,
                                 )
                                 Spacer(modifier = Modifier.width(6.dp))
                                 Text(
@@ -494,6 +494,11 @@ private fun ResolutionStatus.toDisplayText(): String {
         ResolutionStatus.IN_PROGRESS -> "해결 중"
         ResolutionStatus.RESOLVED -> "해결 완료"
     }
+}
+
+private fun String.toSummaryAddress(): String {
+    val addressParts = trim().split(Regex("\\s+"))
+    return addressParts.drop(2).joinToString(" ").ifBlank { trim() }
 }
 
 @Composable

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/map/PinSummaryCard.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/map/PinSummaryCard.kt
@@ -61,6 +61,12 @@ fun PinSummaryCard(
     }
 
     val canEdit = pin.canEditBy(currentUserId)
+    val hasCategoryInfo = when (val detail = pin.detail) {
+        is ShopPinDetail -> !detail.currentNews.isNullOrBlank()
+        is FestivalPinDetail -> detail.startDate != null || detail.endDate != null
+        is IssuePinDetail,
+        is CommunicationPinDetail -> false
+    }
 
     Box(
         modifier = modifier
@@ -237,12 +243,12 @@ fun PinSummaryCard(
             // 3) CategoryInfoRow 또는 CategoryInfoBox
             when (val detail = pin.detail) {
                 is ShopPinDetail -> {
-                    detail.currentNews?.let { news ->
+                    detail.currentNews?.takeIf { it.isNotBlank() }?.let { news ->
                         CategoryInfoBox(
                             text = "최신 소식: $news",
                             modifier = Modifier.padding(horizontal = 0.dp)
                         )
-                        Spacer(modifier = Modifier.height(12.dp))
+                        Spacer(modifier = Modifier.height(6.dp))
                     }
                 }
                 is FestivalPinDetail -> {
@@ -254,7 +260,7 @@ fun PinSummaryCard(
                             text = "기간: ${startDateText ?: "시작일 미정"} ~ ${endDateText ?: "종료일 미정"}",
                             modifier = Modifier.padding(horizontal = 0.dp)
                         )
-                        Spacer(modifier = Modifier.height(12.dp))
+                        Spacer(modifier = Modifier.height(6.dp))
                     }
                 }
 
@@ -269,7 +275,7 @@ fun PinSummaryCard(
                 Text(
                     text = pin.description,
                     style = IssueTypo.Regular15.copy(color = Text),
-                    maxLines = 2,
+                    maxLines = if (hasCategoryInfo) 1 else 2,
                     overflow = TextOverflow.Ellipsis
                 )
                 Spacer(modifier = Modifier.height(4.dp))
@@ -280,8 +286,7 @@ fun PinSummaryCard(
                 )
             }
 
-            // 기존 카테고리별 추가 박스 제거되었으므로 Spacer 유지
-            Spacer(modifier = Modifier.height(12.dp))
+            Spacer(modifier = Modifier.weight(1f))
 
             // 6) BottomActionRow: 이모지/반응 영역 + 커뮤니티 버튼
             Row(

--- a/app/src/main/java/com/issueissyu/fe/ui/screens/pindetail/PinDetailScreen.kt
+++ b/app/src/main/java/com/issueissyu/fe/ui/screens/pindetail/PinDetailScreen.kt
@@ -72,6 +72,7 @@ fun PinDetailScreen(
     pinId: String,
     onBackClick: () -> Unit,
     onReportClick: (String) -> Unit,
+    onCommunityClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
     savedStateHandle: SavedStateHandle? = null,
     viewModel: PinDetailViewModel = hiltViewModel(),
@@ -186,7 +187,9 @@ fun PinDetailScreen(
                         onDeleteClick = { deletePinId ->
                             viewModel.deletePin(deletePinId, onSuccess = onBackClick)
                         },
-                        onCommunityClick = { /* TODO: 커뮤니티 상세 */ },
+                        onCommunityClick = { communityId ->
+                            communityId.toLongOrNull()?.let(onCommunityClick)
+                        },
                         onAttachProofClick = launchResolutionProofCamera,
                         onGoNowClick = viewModel::joinProblemSolver,
                         onPetitionClick = viewModel::joinPetition,


### PR DESCRIPTION
## 🔗 Related Issue
- resolve #71 

## ✨ 작업 개요
> 작업 내용을 간략하게 작성해주세요.
핀 상세 네비게이션과 지도 핀 카드 UI·상호작용을 개선했습니다.
추가적으로 핀 선택시 지도 화면이 해당 핀의 위치로 이동하는 기능을 추가했습니다.

## 체크리스트
- [x] Reviewers, Assignees, Labels를 모두 등록했나요?
- [x] .gitignore 설정을 하였나요?
- [ ] PR 머지 전 반드시 CI가 정상적으로 작동하는지 확인해주세요!

## 📷 이미지 첨부 (선택)
- 작업 결과를 확인할 수 있는 이미지나 GIF를 첨부해주세요.
- UI 변경, API 응답 샘플, 테스트 결과 등이 포함되면 좋아요!

## 🧐 집중 리뷰 요청
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
핀을 선택했을 때 지도 화면이 해당 핀의 위치로 이동하는 기능을 추가했습니다. 괜찮은지 확인 한번 해주시면 감사하겠습니다